### PR TITLE
Remove uprotocol-core-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,21 +274,29 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.6.1</version> <!-- Use the latest version -->
+                <version>0.6.1</version>
                 <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
                     <execution>
                         <id>compile-kt</id>
                         <goals>
                             <goal>compile-custom</goal>
-                            <goal>test-compile-custom</goal>
                         </goals>
+                        <configuration>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+                            <outputDirectory>${project.build.directory}/generated-sources/protobuf/kotlin</outputDirectory>
+                            <pluginId>kotlin</pluginId>
+                        </configuration>
                     </execution>
                 </executions>
                 <configuration>
-                    <pluginId>kotlin</pluginId>
-                    <protocArtifact>com.google.protobuf:protoc:3.25.1:exe:${os.detected.classifier}</protocArtifact>
                     <protoSourceRoot>${project.build.directory}/uprotocol-core-api/src/main/proto</protoSourceRoot>
 
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <kotlin.version>1.9.20</kotlin.version>
+        <kotlin.version>1.9.21</kotlin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
@@ -43,6 +43,8 @@
         <cloudevents.version>2.4.2</cloudevents.version>
 
         <protobuf.version>3.21.10</protobuf.version>
+        <git.tag.name>uprotocol-core-api-1.5.3</git.tag.name>
+
     </properties>
 
     <scm>
@@ -78,6 +80,7 @@
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>3.1.0</version>
             </plugin>
+
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}
@@ -189,6 +192,53 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>clone-repository</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>git</executable>
+
+                            <arguments>
+                                <argument>clone</argument>
+                                <argument>--branch</argument>
+                                <argument>${git.tag.name}</argument>
+                                <argument>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</argument>
+                                <argument>${project.build.directory}/uprotocol-core-api</argument>
+                                neelam-kushwah marked this conversation as resolved.
+                            </arguments>
+                            <!-- Allow non-zero exit code (error) -->
+                            <successCodes>
+                                <successCode>0</successCode>
+                                <successCode>128</successCode> <!-- Git error code for existing repository -->
+                            </successCodes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>pull-repository</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>git</executable>
+                            <workingDirectory>${project.build.directory}/uprotocol-core-api</workingDirectory>
+                            <arguments>
+                                <argument>pull</argument>
+                                <argument>origin</argument>
+                                <argument>${git.tag.name}</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <executions>
@@ -221,6 +271,27 @@
                 </configuration>
                 <version>3.10.1</version> <!-- 3.8.1 -->
             </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version> <!-- Use the latest version -->
+                <executions>
+                    <execution>
+                        <id>compile-kt</id>
+                        <goals>
+                            <goal>compile-custom</goal>
+                            <goal>test-compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <pluginId>kotlin</pluginId>
+                    <protocArtifact>com.google.protobuf:protoc:3.25.1:exe:${os.detected.classifier}</protocArtifact>
+                    <protoSourceRoot>${project.build.directory}/uprotocol-core-api/src/main/proto</protoSourceRoot>
+
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 
@@ -331,7 +402,8 @@
 
         <dependency>
             <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
+            <artifactId>protobuf-kotlin</artifactId>
+            <version>${protobuf.version}</version>
         </dependency>
 
 
@@ -348,12 +420,6 @@
             <version>1.7</version>
         </dependency>
 
-        <!-- uProtocol core API library -->
-        <dependency>
-            <groupId>org.eclipse.uprotocol</groupId>
-            <artifactId>uprotocol-core-api</artifactId>
-            <version>1.5.2</version>
-        </dependency>
 
         <!-- JSON library for JUnit test cases -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,6 @@
                                 <argument>${git.tag.name}</argument>
                                 <argument>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</argument>
                                 <argument>${project.build.directory}/uprotocol-core-api</argument>
-                                neelam-kushwah marked this conversation as resolved.
                             </arguments>
                             <!-- Allow non-zero exit code (error) -->
                             <successCodes>

--- a/src/main/kotlin/org/eclipse/uprotocol/cloudevent/README.adoc
+++ b/src/main/kotlin/org/eclipse/uprotocol/cloudevent/README.adoc
@@ -13,6 +13,98 @@ Factory class that builds the various types of CloudEvents for uProtocol (publis
 
 == Examples
 
-_Coming soon_, for now please refer to the test folder for examples of how to use CloudEventFactory
+
+=== Building an uuri
+[source,kotlin]
+----
+      val use: UEntity = uEntity { name = "body.access" }
+      val res: UResource = uResource {
+          name = "door"
+          instance = "front_left"
+          message = "Door"
+      }
+      val uri: UUri = uUri {
+          entity = use
+          resource = res
+      }
+      String source = LongUriSerializer.instance().serialize(uri);
+----
+
+=== Build proto payload
+[source,kotlin]
+
+----
+
+    io.cloudevents.v1.proto.CloudEvent cloudEventProto = io.cloudevents.v1.proto.CloudEvent.newBuilder()
+            .setSpecVersion("1.0")
+            .setId("hello")
+            .setSource("https://example.com")
+            .setType("example.demo")
+            .setProtoData(Any.newBuilder().build())
+            .build();
+    Any proto_payload= Any.pack(cloudEventProto);
+
+
+----
+
+=== Build UCloudEvent Attributes
+[source,kotlin]
+
+----
+
+
+UCloudEventAttributes uCloudEventAttributes = new UCloudEventAttributes.UCloudEventAttributesBuilder()
+                .withHash("somehash")
+                .withPriority(UPriority.UPRIORITY_CS1)
+                .withTtl(3)
+                .withToken("someOAuthToken")
+                .build();
+
+----
+
+=== Build publish cloud event
+[source,kotlin]
+
+----
+
+
+CloudEvent cloudEvent = CloudEventFactory.publish(source, protoPayload, uCloudEventAttributes);
+# test all attributes
+ assertEquals("1.0", cloudEvent.getSpecVersion().toString());
+ assertNotNull(cloudEvent.getId());
+ assertEquals(source, cloudEvent.getSource().toString());
+ assertEquals(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH), cloudEvent.getType());
+ assertFalse(cloudEvent.getExtensionNames().contains("sink"));
+ assertEquals("somehash", cloudEvent.getExtension("hash"));
+ assertEquals(UPriority.UPRIORITY_CS1.name(), cloudEvent.getExtension("priority"));
+ assertEquals(3, cloudEvent.getExtension("ttl"));
+ assertArrayEquals(protoPayload.toByteArray(), Objects.requireNonNull(cloudEvent.getData()).toBytes());
+
+
+----
+
+
+=== Build cloudevent ↔ umessage 
+[source,kotlin]
+
+----
+
+UMessage result = UCloudEvent.toMessage(cloudEvent);
+assertNotNull(result);
+assertTrue(UCloudEvent.getRequestId(cloudEvent).isPresent());
+assertTrue(UCloudEvent.getTtl(cloudEvent).isPresent());
+assertEquals(UCloudEvent.getTtl(cloudEvent).get(), result.getAttributes().getTtl());
+assertEquals(UCloudEvent.getPayload(cloudEvent).toByteString(),result.getPayload().getValue());
+assertEquals(UCloudEvent.getSource(cloudEvent),LongUriSerializer.instance().serialize(result.getSource()));
+assertTrue(UCloudEvent.getPriority(cloudEvent).isPresent());
+assertEquals(UCloudEvent.getPriority(cloudEvent).get(), String.valueOf(result.getAttributes().getPriority()));
+
+final CloudEvent cloudEvent1 = UCloudEvent.fromMessage(result);
+assertEquals(cloudEvent,cloudEvent1);
+
+
+----
+
+
 
 

--- a/src/main/kotlin/org/eclipse/uprotocol/cloudevent/README.adoc
+++ b/src/main/kotlin/org/eclipse/uprotocol/cloudevent/README.adoc
@@ -27,7 +27,7 @@ Factory class that builds the various types of CloudEvents for uProtocol (publis
           entity = use
           resource = res
       }
-      String source = LongUriSerializer.instance().serialize(uri);
+      source: String = LongUriSerializer.instance().serialize(uri)
 ----
 
 === Build proto payload
@@ -35,14 +35,14 @@ Factory class that builds the various types of CloudEvents for uProtocol (publis
 
 ----
 
-    io.cloudevents.v1.proto.CloudEvent cloudEventProto = io.cloudevents.v1.proto.CloudEvent.newBuilder()
+    val cloudEventProto: io.cloudevents.v1.proto.CloudEvent = io.cloudevents.v1.proto.CloudEvent.newBuilder()
             .setSpecVersion("1.0")
             .setId("hello")
             .setSource("https://example.com")
             .setType("example.demo")
             .setProtoData(Any.newBuilder().build())
-            .build();
-    Any proto_payload= Any.pack(cloudEventProto);
+            .build()
+    Any proto_payload= Any.pack(cloudEventProto)
 
 
 ----
@@ -52,13 +52,12 @@ Factory class that builds the various types of CloudEvents for uProtocol (publis
 
 ----
 
-
-UCloudEventAttributes uCloudEventAttributes = new UCloudEventAttributes.UCloudEventAttributesBuilder()
-                .withHash("somehash")
-                .withPriority(UPriority.UPRIORITY_CS1)
-                .withTtl(3)
-                .withToken("someOAuthToken")
-                .build();
+val uCloudEventAttributes: UCloudEventAttributes = UCloudEventAttributes.UCloudEventAttributesBuilder()
+            .withHash("somehash")
+            .withPriority(UPriority.UPRIORITY_CS1)
+            .withTtl(3)
+            .withToken("someOAuthToken")
+            .build()
 
 ----
 
@@ -68,17 +67,17 @@ UCloudEventAttributes uCloudEventAttributes = new UCloudEventAttributes.UCloudEv
 ----
 
 
-CloudEvent cloudEvent = CloudEventFactory.publish(source, protoPayload, uCloudEventAttributes);
+val cloudEvent: CloudEvent = CloudEventFactory.publish(source, protoPayload, uCloudEventAttributes)
 # test all attributes
- assertEquals("1.0", cloudEvent.getSpecVersion().toString());
- assertNotNull(cloudEvent.getId());
- assertEquals(source, cloudEvent.getSource().toString());
- assertEquals(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH), cloudEvent.getType());
- assertFalse(cloudEvent.getExtensionNames().contains("sink"));
- assertEquals("somehash", cloudEvent.getExtension("hash"));
- assertEquals(UPriority.UPRIORITY_CS1.name(), cloudEvent.getExtension("priority"));
- assertEquals(3, cloudEvent.getExtension("ttl"));
- assertArrayEquals(protoPayload.toByteArray(), Objects.requireNonNull(cloudEvent.getData()).toBytes());
+ assertEquals("1.0", cloudEvent.getSpecVersion().toString())
+ assertNotNull(cloudEvent.getId())
+ assertEquals(source, cloudEvent.getSource().toString())
+ assertEquals(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH), cloudEvent.getType())
+ assertFalse(cloudEvent.getExtensionNames().contains("sink"))
+ assertEquals("somehash", cloudEvent.getExtension("hash"))
+ assertEquals(UPriority.UPRIORITY_CS1.name(), cloudEvent.getExtension("priority"))
+ assertEquals(3, cloudEvent.getExtension("ttl"))
+ assertArrayEquals(protoPayload.toByteArray(), Objects.requireNonNull(cloudEvent.getData()).toBytes())
 
 
 ----
@@ -89,18 +88,18 @@ CloudEvent cloudEvent = CloudEventFactory.publish(source, protoPayload, uCloudEv
 
 ----
 
-UMessage result = UCloudEvent.toMessage(cloudEvent);
-assertNotNull(result);
-assertTrue(UCloudEvent.getRequestId(cloudEvent).isPresent());
-assertTrue(UCloudEvent.getTtl(cloudEvent).isPresent());
-assertEquals(UCloudEvent.getTtl(cloudEvent).get(), result.getAttributes().getTtl());
-assertEquals(UCloudEvent.getPayload(cloudEvent).toByteString(),result.getPayload().getValue());
-assertEquals(UCloudEvent.getSource(cloudEvent),LongUriSerializer.instance().serialize(result.getSource()));
-assertTrue(UCloudEvent.getPriority(cloudEvent).isPresent());
-assertEquals(UCloudEvent.getPriority(cloudEvent).get(), String.valueOf(result.getAttributes().getPriority()));
+val result: UMessage = UCloudEvent.toMessage(cloudEvent)
+assertNotNull(result)
+assertTrue(UCloudEvent.getRequestId(cloudEvent).isPresent())
+assertTrue(UCloudEvent.getTtl(cloudEvent).isPresent())
+assertEquals(UCloudEvent.getTtl(cloudEvent).get(), result.getAttributes().getTtl())
+assertEquals(UCloudEvent.getPayload(cloudEvent).toByteString(),result.getPayload().getValue())
+assertEquals(UCloudEvent.getSource(cloudEvent),LongUriSerializer.instance().serialize(result.getSource()))
+assertTrue(UCloudEvent.getPriority(cloudEvent).isPresent())
+assertEquals(UCloudEvent.getPriority(cloudEvent).get(), String.valueOf(result.getAttributes().getPriority()))
 
-final CloudEvent cloudEvent1 = UCloudEvent.fromMessage(result);
-assertEquals(cloudEvent,cloudEvent1);
+val cloudEvent1: CloudEvent = UCloudEvent.fromMessage(result)
+assertEquals(cloudEvent,cloudEvent1)
 
 
 ----

--- a/src/main/kotlin/org/eclipse/uprotocol/cloudevent/README.adoc
+++ b/src/main/kotlin/org/eclipse/uprotocol/cloudevent/README.adoc
@@ -42,7 +42,7 @@ Factory class that builds the various types of CloudEvents for uProtocol (publis
             .setType("example.demo")
             .setProtoData(Any.newBuilder().build())
             .build()
-    Any proto_payload= Any.pack(cloudEventProto)
+    val proto_payload: Any = Any.pack(cloudEventProto)
 
 
 ----

--- a/src/main/kotlin/org/eclipse/uprotocol/rpc/RpcMapper.kt
+++ b/src/main/kotlin/org/eclipse/uprotocol/rpc/RpcMapper.kt
@@ -92,8 +92,8 @@ interface RpcMapper {
             responseFuture: CompletionStage<UPayload>,
             expectedClazz: Class<T>
         ): CompletionStage<RpcResult<T>> {
-            return responseFuture.handle { payload, exception ->
-                var exception=exception
+            return responseFuture.handle { payload, exc ->
+                var exception=exc
                 // Unexpected exception
                 if (exception != null) {
                     return@handle RpcResult.failure(exception.message!!, exception)

--- a/src/main/kotlin/org/eclipse/uprotocol/rpc/RpcResult.kt
+++ b/src/main/kotlin/org/eclipse/uprotocol/rpc/RpcResult.kt
@@ -26,6 +26,7 @@ package org.eclipse.uprotocol.rpc
 
 import org.eclipse.uprotocol.v1.UCode;
 import org.eclipse.uprotocol.v1.UStatus;
+import org.eclipse.uprotocol.v1.uStatus
 import java.util.function.Function
 import java.util.function.Supplier
 
@@ -88,11 +89,17 @@ sealed class RpcResult<T> {
 
     class Failure<T> internal constructor(internal val value: UStatus) : RpcResult<T>() {
 
-        constructor(code: UCode, message: String) : this(UStatus.newBuilder().setCode(code).setMessage(message).build())
+        constructor(ucode: UCode, msg: String) : this(uStatus {
+            code = ucode
+            message = msg
+        })
 
         companion object {
             fun <T> fromException(e: Exception): RpcResult<T> {
-                return Failure(UStatus.newBuilder().setCode(UCode.UNKNOWN).setMessage(e.message).build())
+                return Failure(uStatus {
+                    code = UCode.UNKNOWN
+                    message = e.message!!
+                })
             }
         }
 
@@ -132,7 +139,9 @@ sealed class RpcResult<T> {
         fun <T> success(value: T): Success<T> = Success(value)
         fun <T> failure(value: UStatus): RpcResult<T> = Failure(value)
         fun <T, U> failure(failure: Failure<U>): RpcResult<T> = Failure(failure.value)
-        fun <T> failure(message: String, e: Throwable): RpcResult<T> = Failure.fromException(IllegalStateException(message, e))
+        fun <T> failure(message: String, e: Throwable): RpcResult<T> =
+            Failure.fromException(IllegalStateException(message, e))
+
         fun <T> failure(code: UCode, message: String): RpcResult<T> = Failure(code, message)
 
         fun <T> flatten(result: RpcResult<RpcResult<T>>): RpcResult<T> = result.flatMap { it }

--- a/src/main/kotlin/org/eclipse/uprotocol/transport/builder/UAttributesBuilder.kt
+++ b/src/main/kotlin/org/eclipse/uprotocol/transport/builder/UAttributesBuilder.kt
@@ -26,8 +26,6 @@ package org.eclipse.uprotocol.transport.builder
 
 import org.eclipse.uprotocol.uuid.factory.UuidFactory
 import org.eclipse.uprotocol.v1.*
-import org.eclipse.uprotocol.v1.UUID
-import java.util.*
 
 /**
  * Builder for easy construction of the UAttributes object.
@@ -36,16 +34,18 @@ class UAttributesBuilder
 /**
  * Construct the UAttributesBuilder with the configurations that are required for every payload transport.
  *
- * @param id       Unique identifier for the message.
- * @param type     Message type such as Publish a state change, RPC request or RPC response.
- * @param priority uProtocol Prioritization classifications.
- */ private constructor(private val id: UUID, private val type: UMessageType, private val priority: UPriority) {
-    private var ttl: Int? = null
-    private var token: String? = null
-    private var sink: UUri? = null
+ * @param uuid       Unique identifier for the message.
+ * @param messageType     Message type such as Publish a state change, RPC request or RPC response.
+ * @param uPriority uProtocol Prioritization classifications.
+ */ private constructor(
+    private val uuid: UUID, private val messageType: UMessageType, private val uPriority: UPriority
+) {
+    private var timeToLive: Int? = null
+    private var tokenAttr: String? = null
+    private var sinkUUri: UUri? = null
     private var plevel: Int? = null
-    private var commstatus: Int? = null
-    private var reqid: UUID? = null
+    private var commStatus: Int? = null
+    private var reqId: UUID? = null
 
     /**
      * Add the time to live in milliseconds.
@@ -54,7 +54,7 @@ class UAttributesBuilder
      * @return Returns the UAttributesBuilder with the configured ttl.
      */
     fun withTtl(ttl: Int?): UAttributesBuilder {
-        this.ttl = ttl
+        timeToLive = ttl
         return this
     }
 
@@ -65,7 +65,7 @@ class UAttributesBuilder
      * @return Returns the UAttributesBuilder with the configured token.
      */
     fun withToken(token: String?): UAttributesBuilder {
-        this.token = token
+        tokenAttr = token
         return this
     }
 
@@ -76,7 +76,7 @@ class UAttributesBuilder
      * @return Returns the UAttributesBuilder with the configured sink.
      */
     fun withSink(sink: UUri?): UAttributesBuilder {
-        this.sink = sink
+        sinkUUri = sink
         return this
     }
 
@@ -98,7 +98,7 @@ class UAttributesBuilder
      * @return Returns the UAttributesBuilder with the configured commstatus.
      */
     fun withCommStatus(commstatus: Int?): UAttributesBuilder {
-        this.commstatus = commstatus
+        commStatus = commstatus
         return this
     }
 
@@ -109,7 +109,7 @@ class UAttributesBuilder
      * @return Returns the UAttributesBuilder with the configured reqid.
      */
     fun withReqId(reqid: UUID?): UAttributesBuilder {
-        this.reqid = reqid
+        reqId = reqid
         return this
     }
 
@@ -119,26 +119,29 @@ class UAttributesBuilder
      * @return Returns a constructed
      */
     fun build(): UAttributes {
-        val attributesBuilder = UAttributes.newBuilder().setId(id).setType(type).setPriority(priority)
-        if (sink != null) {
-            attributesBuilder.setSink(sink)
+        return uAttributes {
+            id = uuid
+            type = messageType
+            priority = uPriority
+            if (sinkUUri != null) {
+                sink = sinkUUri!!
+            }
+            if (timeToLive != null) {
+                ttl = timeToLive!!
+            }
+            if (plevel != null) {
+                permissionLevel = plevel!!
+            }
+            if (commStatus != null) {
+                commstatus = commStatus!!
+            }
+            if (reqId != null) {
+                reqid = reqId!!
+            }
+            if (tokenAttr != null) {
+                token = tokenAttr!!
+            }
         }
-        if (ttl != null) {
-            attributesBuilder.setTtl(ttl!!)
-        }
-        if (plevel != null) {
-            attributesBuilder.setPermissionLevel(plevel!!)
-        }
-        if (commstatus != null) {
-            attributesBuilder.setCommstatus(commstatus!!)
-        }
-        if (reqid != null) {
-            attributesBuilder.setReqid(reqid)
-        }
-        if (token != null) {
-            attributesBuilder.setToken(token)
-        }
-        return attributesBuilder.build()
     }
 
     companion object {
@@ -148,8 +151,9 @@ class UAttributesBuilder
          * @return Returns the UAttributesBuilder with the configured priority.
          */
         fun publish(priority: UPriority): UAttributesBuilder {
-            return UAttributesBuilder(UuidFactory.Factories.UPROTOCOL.factory().create(),
-                    UMessageType.UMESSAGE_TYPE_PUBLISH, priority)
+            return UAttributesBuilder(
+                UuidFactory.Factories.UPROTOCOL.factory().create(), UMessageType.UMESSAGE_TYPE_PUBLISH, priority
+            )
         }
 
         /**
@@ -159,8 +163,9 @@ class UAttributesBuilder
          * @return Returns the UAttributesBuilder with the configured priority and sink.
          */
         fun notification(priority: UPriority, sink: UUri): UAttributesBuilder {
-            return UAttributesBuilder(UuidFactory.Factories.UPROTOCOL.factory().create(),
-                    UMessageType.UMESSAGE_TYPE_PUBLISH, priority).withSink(sink)
+            return UAttributesBuilder(
+                UuidFactory.Factories.UPROTOCOL.factory().create(), UMessageType.UMESSAGE_TYPE_PUBLISH, priority
+            ).withSink(sink)
         }
 
         /**
@@ -171,8 +176,9 @@ class UAttributesBuilder
          * @return Returns the UAttributesBuilder with the configured priority, sink and ttl.
          */
         fun request(priority: UPriority, sink: UUri, ttl: Int): UAttributesBuilder {
-            return UAttributesBuilder(UuidFactory.Factories.UPROTOCOL.factory().create(),
-                    UMessageType.UMESSAGE_TYPE_REQUEST, priority).withTtl(ttl).withSink(sink)
+            return UAttributesBuilder(
+                UuidFactory.Factories.UPROTOCOL.factory().create(), UMessageType.UMESSAGE_TYPE_REQUEST, priority
+            ).withTtl(ttl).withSink(sink)
         }
 
         /**
@@ -183,8 +189,9 @@ class UAttributesBuilder
          * @return Returns the UAttributesBuilder with the configured priority, sink and reqid.
          */
         fun response(priority: UPriority, sink: UUri, reqid: UUID): UAttributesBuilder {
-            return UAttributesBuilder(UuidFactory.Factories.UPROTOCOL.factory().create(),
-                    UMessageType.UMESSAGE_TYPE_RESPONSE, priority).withSink(sink).withReqId(reqid)
+            return UAttributesBuilder(
+                UuidFactory.Factories.UPROTOCOL.factory().create(), UMessageType.UMESSAGE_TYPE_RESPONSE, priority
+            ).withSink(sink).withReqId(reqid)
         }
     }
 }

--- a/src/main/kotlin/org/eclipse/uprotocol/uri/README.adoc
+++ b/src/main/kotlin/org/eclipse/uprotocol/uri/README.adoc
@@ -35,16 +35,16 @@ val uri = uUri {
 === Validating
 [,kotlin]
 ----
-final ValidationResult status = UriValidator.validateRpcMethod(uuri);
-            assertTrue(status.isSuccess());
+        val status:ValidationResult = UriValidator.validateRpcMethod(uuri)
+        assertTrue(status.isSuccess())
 ----
 
 === Serializing & Deserializing
-[,java]
+[,kotlin]
 ----
-        UUri uri = .../* UUri example above */
-        byte[] micro = MicroUriSerializer.instance().serialize(uri);
-        String long = LongUriSerializer.instance().serialize(uri);
-        UUri uri2 = UriSerializer.buildResolved(long, micro);
-        assertTrue(uri.equals(uri2));
+        val uri: UUri = .../* UUri example above */
+        val micro: ByteArray = MicroUriSerializer.instance().serialize(uri)
+        val long: String = LongUriSerializer.instance().serialize(uri)
+        val uri2: UUri = UriSerializer.buildResolved(long, micro)
+        assertTrue(uri.equals(uri2))
 ----

--- a/src/main/kotlin/org/eclipse/uprotocol/uri/README.adoc
+++ b/src/main/kotlin/org/eclipse/uprotocol/uri/README.adoc
@@ -16,24 +16,24 @@ IMPORTANT: For more details about the data model, various formats (object, long,
 When building UUri, you can choose to populate it with only names, only numbers, or both (resolved). When you should use each is described the best practice section of https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/basics/uri.adoc[uProtocol URI Specifications].
 
 === Building an RPC Method
-[,java]
+[,kotlin]
 ----
-UUri uri = UUri.newBuilder()
-    .setAuthority(UAuthority.newBuilder()
-        .setName("MyDevice")
-        .setIp(ByteString.copyFrom(InetAddress.getByName("192.168.1.100").getAddress()))
-        .setId(ByteString.copyFrom("3GTU2NEC8HG403825").build()))
-    .setEntity(UEntity.newBuilder()
-        .setName("HartleyService")
-        .setId(10203)
-        .setVersionMajor(1)
-        .build())
-    .setResource(UResourceBuilder.forRpcRequest("Raise", 10))
-    .build();
+val uri = uUri {
+            authority = uAuthority {
+                name = "MyDevice"
+                ip = ByteString.copyFrom(InetAddress.getByName("192.168.1.100").address)
+            }
+            entity = uEntity {
+                name = "Service"
+                id = 10203
+                versionMajor = 1
+            }
+            resource = UResourceBuilder.forRpcRequest("Raise", 10)
+        }
 ----
 
 === Validating
-[,java]
+[,kotlin]
 ----
 final ValidationResult status = UriValidator.validateRpcMethod(uuri);
             assertTrue(status.isSuccess());

--- a/src/main/kotlin/org/eclipse/uprotocol/uri/builder/UResourceBuilder.kt
+++ b/src/main/kotlin/org/eclipse/uprotocol/uri/builder/UResourceBuilder.kt
@@ -24,8 +24,9 @@
 
 package org.eclipse.uprotocol.uri.builder
 
-import java.util.Objects
 import org.eclipse.uprotocol.v1.UResource
+import org.eclipse.uprotocol.v1.uResource
+import java.util.*
 
 interface UResourceBuilder {
     companion object {
@@ -36,11 +37,11 @@ interface UResourceBuilder {
          * @return Returns a UResource for an RPC response.
          */
         fun forRpcResponse(): UResource {
-            return UResource.newBuilder()
-                .setName("rpc")
-                .setInstance("response")
-                .setId(0)
-                .build()
+            return uResource {
+                name = "rpc"
+                instance = "response"
+                id = 0
+            }
         }
 
         /**
@@ -58,15 +59,12 @@ interface UResourceBuilder {
          * @param id The ID of the request.
          * @return Returns a UResource for an RPC request.
          */
-        private fun forRpcRequest(method: String?, id: Int?): UResource {
-            val builder: UResource.Builder = UResource.newBuilder().setName("rpc")
-            if (method != null) {
-                builder.setInstance(method)
+        fun forRpcRequest(method: String?, idRes: Int?): UResource {
+            return uResource {
+                name = "rpc"
+                if (method != null) instance = method
+                if (idRes != null) id = idRes
             }
-            if (id != null) {
-                builder.setId(id)
-            }
-            return builder.build()
         }
 
         /**
@@ -84,9 +82,9 @@ interface UResourceBuilder {
          * @param id The ID of the request.
          * @return Returns a UResource for an RPC request.
          */
-        fun fromId(id: Int): UResource {
-            Objects.requireNonNull(id, "id cannot be null")
-            return if (id < MAX_RPC_ID) forRpcRequest(id) else UResource.newBuilder().setId(id).build()
+        fun fromId(idRes: Int): UResource {
+            Objects.requireNonNull(idRes, "id cannot be null")
+            return if (idRes < MAX_RPC_ID) forRpcRequest(idRes) else uResource { id= idRes}
         }
     }
 }

--- a/src/main/kotlin/org/eclipse/uprotocol/uuid/README.adoc
+++ b/src/main/kotlin/org/eclipse/uprotocol/uuid/README.adoc
@@ -8,7 +8,7 @@ Implementation of https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/
 
 == Examples
 
-[source,java]
+[source,kotlin]
 ----
     final UUID uuid = UUIDFactory.Factories.UPROTOCOL.factory().create();
     final Optional<UuidUtils.Version> version = UuidUtils.getVersion(uuid);

--- a/src/main/kotlin/org/eclipse/uprotocol/uuid/README.adoc
+++ b/src/main/kotlin/org/eclipse/uprotocol/uuid/README.adoc
@@ -10,29 +10,29 @@ Implementation of https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/
 
 [source,kotlin]
 ----
-    final UUID uuid = UUIDFactory.Factories.UPROTOCOL.factory().create();
-    final Optional<UuidUtils.Version> version = UuidUtils.getVersion(uuid);
-    final Optional<Long> time = UuidUtils.getTime(uuid);
-    final Optional<byte[]> bytes = UuidUtils.toBytes(uuid);
-    final Optional<String> uuidString = UuidUtils.toString(uuid);
+    val uuid: UUID = UuidFactory.Factories.UPROTOCOL.factory().create()
+    val version: Optional<UuidUtils.Version> = UuidUtils.getVersion(uuid);
+    val time: Optional<Long> = UuidUtils.getTime(uuid);
+    val bytes = MicroUuidSerializer.instance().serialize(uuid)
+    val uuidString = LongUuidSerializer.instance().serialize(uuid)
 
-    assertNotNull(uuid);
-    assertTrue(UuidUtils.isUProtocol(uuid));
-    assertTrue(UuidUtils.isUuid(uuid));
-    assertFalse(UuidUtils.isUuidv6(uuid));
-    assertTrue(version.isPresent());
-    assertTrue(time.isPresent());
-    assertEquals(time.get(), now.toEpochMilli());
-    
-    assertTrue(bytes.isPresent());
-    assertTrue(uuidString.isPresent());
+    assertNotNull(uuid)
+    assertFalse(UuidUtils.isUuidv6(uuid))
+    assertFalse(UuidUtils.isUProtocol(uuid))
+    assertTrue(version.isPresent)
+    assertEquals(version.get(), UuidUtils.Version.VERSION_UNKNOWN)
+    assertFalse(time.isPresent)
+    assertTrue(bytes.isNotEmpty())
+    assertFalse(uuidString.isBlank())
+    assertFalse(UuidUtils.isUuidv6(null))
+    assertFalse(UuidUtils.isUProtocol(null))
+    assertFalse(UuidUtils.isUuid(null))
 
-    final Optional<UUID> uuid1 = UuidUtils.fromBytes(bytes.get());
+    val uuid1: UUID = MicroUuidSerializer.instance().deserialize(bytes)
+    assertTrue(uuid1 == UUID.getDefaultInstance())
+    assertEquals(uuid, uuid1)
 
-    assertTrue(uuid1.isPresent());
-    assertEquals(uuid, uuid1.get());
-
-    final Optional<UUID> uuid2 = UuidUtils.fromString(uuidString.get());
-    assertTrue(uuid2.isPresent());
-    assertEquals(uuid, uuid2.get());
+    val uuid2: UUID = LongUuidSerializer.instance().deserialize(uuidString)
+    assertTrue(uuid2 == UUID.getDefaultInstance())
+    assertEquals(uuid, uuid2)
 ----

--- a/src/main/kotlin/org/eclipse/uprotocol/uuid/serializer/LongUuidSerializer.kt
+++ b/src/main/kotlin/org/eclipse/uprotocol/uuid/serializer/LongUuidSerializer.kt
@@ -24,6 +24,7 @@
 package org.eclipse.uprotocol.uuid.serializer
 
 import org.eclipse.uprotocol.v1.UUID
+import org.eclipse.uprotocol.v1.uUID
 
 /**
  * UUID Serializer interface used to serialize/deserialize UUIDs to/from a string
@@ -34,8 +35,11 @@ class LongUuidSerializer private constructor() : UuidSerializer<String?> {
             UUID.getDefaultInstance()
         } else try {
             val uuidJava = java.util.UUID.fromString(uuid)
-            UUID.newBuilder().setMsb(uuidJava.mostSignificantBits)
-                    .setLsb(uuidJava.leastSignificantBits).build()
+            uUID {
+                msb = uuidJava.mostSignificantBits
+                lsb = uuidJava.leastSignificantBits
+            }
+
         } catch (e: IllegalArgumentException) {
             UUID.getDefaultInstance()
         }

--- a/src/main/kotlin/org/eclipse/uprotocol/uuid/serializer/MicroUuidSerializer.kt
+++ b/src/main/kotlin/org/eclipse/uprotocol/uuid/serializer/MicroUuidSerializer.kt
@@ -24,16 +24,20 @@
 package org.eclipse.uprotocol.uuid.serializer
 
 import org.eclipse.uprotocol.v1.UUID
+import org.eclipse.uprotocol.v1.uUID
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
 class MicroUuidSerializer private constructor() : UuidSerializer<ByteArray?> {
     override fun deserialize(uuid: ByteArray?): UUID {
-        if (uuid==null ||uuid.size != 16) {
+        if (uuid == null || uuid.size != 16) {
             return UUID.getDefaultInstance()
         }
         val byteBuffer = ByteBuffer.wrap(uuid)
-        return UUID.newBuilder().setMsb(byteBuffer.getLong()).setLsb(byteBuffer.getLong()).build()
+        return uUID {
+            msb = byteBuffer.getLong()
+            lsb = byteBuffer.getLong()
+        }
     }
 
     override fun serialize(uuid: UUID?): ByteArray {

--- a/src/main/kotlin/org/eclipse/uprotocol/uuid/validate/UuidValidator.kt
+++ b/src/main/kotlin/org/eclipse/uprotocol/uuid/validate/UuidValidator.kt
@@ -25,10 +25,11 @@
 package org.eclipse.uprotocol.uuid.validate
 
 import com.github.f4b6a3.uuid.enums.UuidVariant
-import org.eclipse.uprotocol.v1.UStatus;
-import org.eclipse.uprotocol.v1.UCode;
 import org.eclipse.uprotocol.uuid.factory.UuidUtils
+import org.eclipse.uprotocol.v1.UCode
+import org.eclipse.uprotocol.v1.UStatus
 import org.eclipse.uprotocol.v1.UUID
+import org.eclipse.uprotocol.v1.uStatus
 import org.eclipse.uprotocol.validation.ValidationResult
 import java.util.*
 
@@ -37,9 +38,7 @@ import java.util.*
  */
 abstract class UuidValidator {
     enum class Validators(private val uuidValidator: UuidValidator) {
-        UNKNOWN(InvalidValidator()),
-        UUIDV6(UUIDv6Validator()),
-        UPROTOCOL(UUIDv8Validator());
+        UNKNOWN(InvalidValidator()), UUIDV6(UUIDv6Validator()), UPROTOCOL(UUIDv8Validator());
 
         fun validator(): UuidValidator {
             return uuidValidator
@@ -48,17 +47,14 @@ abstract class UuidValidator {
 
     fun validate(uuid: UUID?): UStatus {
         val errorMessages = listOf(
-                validateVersion(uuid),
-                validateVariant(uuid),
-                validateTime(uuid)
-        )
-                .filter { it.isFailure() }.joinToString(",") { it.getMessage() }
+            validateVersion(uuid), validateVariant(uuid), validateTime(uuid)
+        ).filter { it.isFailure() }.joinToString(",") { it.getMessage() }
 
         return if (errorMessages.isBlank()) ValidationResult.success().toStatus()
-        else UStatus.newBuilder()
-                .setCode(UCode.INVALID_ARGUMENT)
-                .setMessage(errorMessages)
-                .build()
+        else uStatus {
+            code = UCode.INVALID_ARGUMENT
+            message = errorMessages
+        }
     }
 
 

--- a/src/main/kotlin/org/eclipse/uprotocol/validation/ValidationResult.kt
+++ b/src/main/kotlin/org/eclipse/uprotocol/validation/ValidationResult.kt
@@ -24,8 +24,9 @@
 
 package org.eclipse.uprotocol.validation
 
-import org.eclipse.uprotocol.v1.UStatus;
-import org.eclipse.uprotocol.v1.UCode;
+import org.eclipse.uprotocol.v1.UCode
+import org.eclipse.uprotocol.v1.UStatus
+import org.eclipse.uprotocol.v1.uStatus
 import java.util.*
 
 /**
@@ -34,7 +35,10 @@ import java.util.*
 sealed class ValidationResult {
 
     companion object {
-        val STATUS_SUCCESS: UStatus = UStatus.newBuilder().setCode(UCode.OK).setMessage("OK").build()
+        val STATUS_SUCCESS: UStatus = uStatus {
+            code = UCode.OK
+            message = "OK"
+        }
         private val SUCCESS: ValidationResult = Success
 
         fun success(): ValidationResult = SUCCESS
@@ -44,18 +48,22 @@ sealed class ValidationResult {
     fun isFailure(): Boolean {
         return !isSuccess()
     }
+
     abstract fun toStatus(): UStatus
     abstract fun isSuccess(): Boolean
     abstract fun getMessage(): String
 
-    class Failure(private val message: String) : ValidationResult() {
+    class Failure(private val msg: String) : ValidationResult() {
 
         init {
-            Objects.requireNonNull(message)
+            Objects.requireNonNull(msg)
         }
 
         override fun toStatus(): UStatus {
-            return UStatus.newBuilder().setCode(UCode.INVALID_ARGUMENT).setMessage(message).build()
+            return uStatus {
+                code = UCode.INVALID_ARGUMENT
+                message = msg
+            }
         }
 
         override fun isSuccess(): Boolean {
@@ -63,11 +71,11 @@ sealed class ValidationResult {
         }
 
         override fun getMessage(): String {
-            return message
+            return msg
         }
 
         override fun toString(): String {
-            return "ValidationResult.Failure(message='$message')"
+            return "ValidationResult.Failure(message='$msg')"
         }
     }
 

--- a/src/test/kotlin/org/eclipse/uprotocol/cloudevent/factory/CloudEventFactoryTest.kt
+++ b/src/test/kotlin/org/eclipse/uprotocol/cloudevent/factory/CloudEventFactoryTest.kt
@@ -26,11 +26,11 @@ import io.cloudevents.core.builder.CloudEventBuilder
 import org.eclipse.uprotocol.cloudevent.datamodel.UCloudEventAttributes
 import org.eclipse.uprotocol.uri.serializer.LongUriSerializer
 import org.eclipse.uprotocol.v1.*
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.net.URI
-import java.util.Objects
-import org.junit.jupiter.api.Assertions.*
+import java.util.*
 
 internal class CloudEventFactoryTest {
     @Test
@@ -42,18 +42,13 @@ internal class CloudEventFactoryTest {
         val protoPayload = buildProtoPayloadForTest()
 
         // additional attributes
-        val uCloudEventAttributes: UCloudEventAttributes = UCloudEventAttributes.UCloudEventAttributesBuilder()
-            .withHash("somehash")
-            .withPriority(UPriority.UPRIORITY_CS1)
-            .withTtl(3)
-            .withToken("someOAuthToken")
-            .build()
+        val uCloudEventAttributes: UCloudEventAttributes =
+            UCloudEventAttributes.UCloudEventAttributesBuilder().withHash("somehash")
+                .withPriority(UPriority.UPRIORITY_CS1).withTtl(3).withToken("someOAuthToken").build()
 
         // build the cloud event
         val cloudEventBuilder: CloudEventBuilder = CloudEventFactory.buildBaseCloudEvent(
-            "testme", source,
-            protoPayload.toByteArray(), protoPayload.typeUrl,
-            uCloudEventAttributes
+            "testme", source, protoPayload.toByteArray(), protoPayload.typeUrl, uCloudEventAttributes
         )
         cloudEventBuilder.withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
         val cloudEvent: CloudEvent = cloudEventBuilder.build()
@@ -78,22 +73,16 @@ internal class CloudEventFactoryTest {
         val protoPayload = buildProtoPayloadForTest()
 
         // additional attributes
-        val uCloudEventAttributes: UCloudEventAttributes = UCloudEventAttributes.UCloudEventAttributesBuilder()
-            .withHash("somehash")
-            .withPriority(UPriority.UPRIORITY_CS1)
-            .withTtl(3)
-            .withToken("someOAuthToken")
-            .build()
+        val uCloudEventAttributes: UCloudEventAttributes =
+            UCloudEventAttributes.UCloudEventAttributesBuilder().withHash("somehash")
+                .withPriority(UPriority.UPRIORITY_CS1).withTtl(3).withToken("someOAuthToken").build()
 
         // build the cloud event
         val cloudEventBuilder: CloudEventBuilder = CloudEventFactory.buildBaseCloudEvent(
-            "testme", source,
-            protoPayload.toByteArray(), protoPayload.typeUrl,
-            uCloudEventAttributes
+            "testme", source, protoPayload.toByteArray(), protoPayload.typeUrl, uCloudEventAttributes
         )
         cloudEventBuilder.withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
-            .withDataContentType(DATA_CONTENT_TYPE)
-            .withDataSchema(URI.create(protoPayload.typeUrl))
+            .withDataContentType(DATA_CONTENT_TYPE).withDataSchema(URI.create(protoPayload.typeUrl))
         val cloudEvent: CloudEvent = cloudEventBuilder.build()
 
         // test all attributes
@@ -103,8 +92,7 @@ internal class CloudEventFactoryTest {
         assertEquals(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH), cloudEvent.type)
         assertEquals(DATA_CONTENT_TYPE, cloudEvent.dataContentType)
         assertEquals(
-            "type.googleapis.com/io.cloudevents.v1.CloudEvent",
-            Objects.requireNonNull(cloudEvent.dataSchema).toString()
+            "type.googleapis.com/io.cloudevents.v1.CloudEvent", Objects.requireNonNull(cloudEvent.dataSchema).toString()
         )
         assertFalse(cloudEvent.extensionNames.contains("sink"))
         assertEquals("somehash", cloudEvent.getExtension("hash"))
@@ -127,9 +115,7 @@ internal class CloudEventFactoryTest {
 
         // build the cloud event
         val cloudEventBuilder: CloudEventBuilder = CloudEventFactory.buildBaseCloudEvent(
-            "testme", source,
-            protoPayload.toByteArray(), protoPayload.typeUrl,
-            uCloudEventAttributes
+            "testme", source, protoPayload.toByteArray(), protoPayload.typeUrl, uCloudEventAttributes
         )
         cloudEventBuilder.withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
         val cloudEvent: CloudEvent = cloudEventBuilder.build()
@@ -155,11 +141,9 @@ internal class CloudEventFactoryTest {
         val protoPayload = buildProtoPayloadForTest()
 
         // additional attributes
-        val uCloudEventAttributes: UCloudEventAttributes = UCloudEventAttributes.UCloudEventAttributesBuilder()
-            .withHash("somehash")
-            .withPriority(UPriority.UPRIORITY_CS1)
-            .withTtl(3)
-            .build()
+        val uCloudEventAttributes: UCloudEventAttributes =
+            UCloudEventAttributes.UCloudEventAttributesBuilder().withHash("somehash")
+                .withPriority(UPriority.UPRIORITY_CS1).withTtl(3).build()
         val cloudEvent: CloudEvent = CloudEventFactory.publish(source, protoPayload, uCloudEventAttributes)
         assertEquals("1.0", cloudEvent.specVersion.toString())
         assertNotNull(cloudEvent.id)
@@ -186,11 +170,9 @@ internal class CloudEventFactoryTest {
         val protoPayload = buildProtoPayloadForTest()
 
         // additional attributes
-        val uCloudEventAttributes: UCloudEventAttributes = UCloudEventAttributes.UCloudEventAttributesBuilder()
-            .withHash("somehash")
-            .withPriority(UPriority.UPRIORITY_CS2)
-            .withTtl(3)
-            .build()
+        val uCloudEventAttributes: UCloudEventAttributes =
+            UCloudEventAttributes.UCloudEventAttributesBuilder().withHash("somehash")
+                .withPriority(UPriority.UPRIORITY_CS2).withTtl(3).build()
 
         // build the cloud event of type publish with destination - a notification
         val cloudEvent: CloudEvent = CloudEventFactory.notification(source, sink, protoPayload, uCloudEventAttributes)
@@ -220,15 +202,11 @@ internal class CloudEventFactoryTest {
         val protoPayload = buildProtoPayloadForTest()
 
         // additional attributes
-        val uCloudEventAttributes: UCloudEventAttributes = UCloudEventAttributes.UCloudEventAttributesBuilder()
-            .withHash("somehash")
-            .withPriority(UPriority.UPRIORITY_CS2)
-            .withTtl(3)
-            .withToken("someOAuthToken")
-            .build()
+        val uCloudEventAttributes: UCloudEventAttributes =
+            UCloudEventAttributes.UCloudEventAttributesBuilder().withHash("somehash")
+                .withPriority(UPriority.UPRIORITY_CS2).withTtl(3).withToken("someOAuthToken").build()
         val cloudEvent: CloudEvent = CloudEventFactory.request(
-            applicationUriForRPC, serviceMethodUri,
-            protoPayload, uCloudEventAttributes
+            applicationUriForRPC, serviceMethodUri, protoPayload, uCloudEventAttributes
         )
         assertEquals("1.0", cloudEvent.specVersion.toString())
         assertNotNull(cloudEvent.id)
@@ -257,14 +235,15 @@ internal class CloudEventFactoryTest {
         val protoPayload = buildProtoPayloadForTest()
 
         // additional attributes
-        val uCloudEventAttributes: UCloudEventAttributes = UCloudEventAttributes.UCloudEventAttributesBuilder()
-            .withHash("somehash")
-            .withPriority(UPriority.UPRIORITY_CS2)
-            .withTtl(3)
-            .build()
+        val uCloudEventAttributes: UCloudEventAttributes =
+            UCloudEventAttributes.UCloudEventAttributesBuilder().withHash("somehash")
+                .withPriority(UPriority.UPRIORITY_CS2).withTtl(3).build()
         val cloudEvent: CloudEvent = CloudEventFactory.response(
-            applicationUriForRPC, serviceMethodUri,
-            "requestIdFromRequestCloudEvent", protoPayload, uCloudEventAttributes
+            applicationUriForRPC,
+            serviceMethodUri,
+            "requestIdFromRequestCloudEvent",
+            protoPayload,
+            uCloudEventAttributes
         )
         assertEquals("1.0", cloudEvent.specVersion.toString())
         assertNotNull(cloudEvent.id)
@@ -290,13 +269,12 @@ internal class CloudEventFactoryTest {
         val serviceMethodUri = buildUriForTest()
 
         // additional attributes
-        val uCloudEventAttributes: UCloudEventAttributes = UCloudEventAttributes.UCloudEventAttributesBuilder()
-            .withHash("somehash")
-            .withPriority(UPriority.UPRIORITY_CS2)
-            .withTtl(3)
-            .build()
+        val uCloudEventAttributes: UCloudEventAttributes =
+            UCloudEventAttributes.UCloudEventAttributesBuilder().withHash("somehash")
+                .withPriority(UPriority.UPRIORITY_CS2).withTtl(3).build()
         val cloudEvent: CloudEvent = CloudEventFactory.failedResponse(
-            applicationUriForRPC, serviceMethodUri,
+            applicationUriForRPC,
+            serviceMethodUri,
             "requestIdFromRequestCloudEvent",
             UCode.INVALID_ARGUMENT_VALUE,
             uCloudEventAttributes
@@ -326,13 +304,12 @@ internal class CloudEventFactoryTest {
 
 
         // additional attributes
-        val uCloudEventAttributes: UCloudEventAttributes = UCloudEventAttributes.UCloudEventAttributesBuilder()
-            .withHash("somehash")
-            .withPriority(UPriority.UPRIORITY_CS2)
-            .withTtl(3)
-            .build()
+        val uCloudEventAttributes: UCloudEventAttributes =
+            UCloudEventAttributes.UCloudEventAttributesBuilder().withHash("somehash")
+                .withPriority(UPriority.UPRIORITY_CS2).withTtl(3).build()
         val cloudEvent: CloudEvent = CloudEventFactory.failedResponse(
-            applicationUriForRPC, serviceMethodUri,
+            applicationUriForRPC,
+            serviceMethodUri,
             "requestIdFromRequestCloudEvent",
             UCode.INVALID_ARGUMENT_VALUE,
             uCloudEventAttributes
@@ -351,26 +328,22 @@ internal class CloudEventFactoryTest {
     }
 
     private fun buildUriForTest(): String {
-        val uri: UUri = UUri.newBuilder()
-            .setEntity(UEntity.newBuilder().setName("body.access"))
-            .setResource(
-                UResource.newBuilder()
-                    .setName("door")
-                    .setInstance("front_left")
-                    .setMessage("Door")
-            )
-            .build()
+        val uri: UUri = uUri {
+            entity = uEntity { name = "body.access" }
+            resource = uResource {
+                name = "door"
+                instance = "front_left"
+                message = "Door"
+            }
+        }
+
         return LongUriSerializer.instance().serialize(uri)
     }
 
     private fun buildProtoPayloadForTest(): Any {
-        val cloudEventProto: io.cloudevents.v1.proto.CloudEvent = io.cloudevents.v1.proto.CloudEvent.newBuilder()
-            .setSpecVersion("1.0")
-            .setId("hello")
-            .setSource("https://example.com")
-            .setType("example.demo")
-            .setProtoData(Any.newBuilder().build())
-            .build()
+        val cloudEventProto: io.cloudevents.v1.proto.CloudEvent =
+            io.cloudevents.v1.proto.CloudEvent.newBuilder().setSpecVersion("1.0").setId("hello")
+                .setSource("https://example.com").setType("example.demo").setProtoData(Any.newBuilder().build()).build()
         return Any.pack(cloudEventProto)
     }
 

--- a/src/test/kotlin/org/eclipse/uprotocol/cloudevent/factory/UCloudEventTest.kt
+++ b/src/test/kotlin/org/eclipse/uprotocol/cloudevent/factory/UCloudEventTest.kt
@@ -92,7 +92,6 @@ internal class UCloudEventTest {
     }
 
 
-
     @Test
     @DisplayName("Test extracting the hash from a CloudEvent when the hash exists.")
     fun test_extract_hash_from_cloudevent_when_hash_exists() {
@@ -181,8 +180,7 @@ internal class UCloudEventTest {
 
     @Test
     @DisplayName(
-        "Test a CloudEvent has a platform communication error when the platform communication error does " +
-                "not" + " exist."
+        "Test a CloudEvent has a platform communication error when the platform communication error does " + "not" + " exist."
     )
     fun test_cloudevent_has_platform_error_when_platform_error_does_not_exist() {
         val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest()
@@ -193,8 +191,7 @@ internal class UCloudEventTest {
 
     @Test
     @DisplayName(
-        "Test extracting the platform communication error from a CloudEvent when the platform communication "
-                + "error exists but in the wrong format."
+        "Test extracting the platform communication error from a CloudEvent when the platform communication " + "error exists but in the wrong format."
     )
     fun test_extract_platform_error_from_cloudevent_when_platform_error_exists_in_wrong_format() {
         val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withExtension("commstatus", "boom")
@@ -205,13 +202,11 @@ internal class UCloudEventTest {
 
     @Test
     @DisplayName(
-        "Test extracting the platform communication error from a CloudEvent when the platform communication "
-                + "error exists."
+        "Test extracting the platform communication error from a CloudEvent when the platform communication " + "error exists."
     )
     fun test_extract_platform_error_from_cloudevent_when_platform_error_exists() {
         val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withExtension(
-            "commstatus",
-            UCode.INVALID_ARGUMENT_VALUE
+            "commstatus", UCode.INVALID_ARGUMENT_VALUE
         )
         val cloudEvent: CloudEvent = builder.build()
         val communicationStatus: Int = UCloudEvent.getCommunicationStatus(cloudEvent)
@@ -220,8 +215,7 @@ internal class UCloudEventTest {
 
     @Test
     @DisplayName(
-        "Test extracting the platform communication error from a CloudEvent when the platform communication "
-                + "error does not exist."
+        "Test extracting the platform communication error from a CloudEvent when the platform communication " + "error does not exist."
     )
     fun test_extract_platform_error_from_cloudevent_when_platform_error_does_not_exist() {
         val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest()
@@ -318,16 +312,15 @@ internal class UCloudEventTest {
     @Test
     @DisplayName("Test if the CloudEvent is not expired using creation date when configured ttl is 500 milliseconds " + "with creation date of now.")
     fun test_cloudevent_is_not_expired_cd_when_ttl_500_mili_with_creation_date_of_now() {
-        val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withTime(OffsetDateTime.now())
-            .withExtension("ttl", 500)
+        val builder: CloudEventBuilder =
+            buildBaseCloudEventBuilderForTest().withTime(OffsetDateTime.now()).withExtension("ttl", 500)
         val cloudEvent: CloudEvent = builder.build()
         assertFalse(UCloudEvent.isExpiredByCloudEventCreationDate(cloudEvent))
     }
 
     @Test
     @DisplayName(
-        "Test if the CloudEvent is expired using creation date when configured ttl is 500 milliseconds with "
-                + "creation date of yesterday."
+        "Test if the CloudEvent is expired using creation date when configured ttl is 500 milliseconds with " + "creation date of yesterday."
     )
     fun test_cloudevent_is_expired_cd_when_ttl_500_mili_with_creation_date_of_yesterday() {
         val yesterday: OffsetDateTime = OffsetDateTime.now().minus(1, ChronoUnit.DAYS)
@@ -382,8 +375,8 @@ internal class UCloudEventTest {
     fun test_cloudevent_is_not_expired_when_ttl_is_large_number_mili() {
         val uuid: UUID = UuidFactory.Factories.UPROTOCOL.factory().create()
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
-        val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withExtension("ttl", Integer.MAX_VALUE)
-            .withId(strUuid)
+        val builder: CloudEventBuilder =
+            buildBaseCloudEventBuilderForTest().withExtension("ttl", Integer.MAX_VALUE).withId(strUuid)
         val cloudEvent: CloudEvent = builder.build()
         assertFalse(UCloudEvent.isExpired(cloudEvent))
     }
@@ -424,8 +417,10 @@ internal class UCloudEventTest {
     @DisplayName("Test if the CloudEvent does not have a UUIDV8 id.")
     fun test_cloudevent_does_not_have_a_UUIDV8_id() {
         val uuidJava: java.util.UUID = java.util.UUID.randomUUID()
-        val uuid: UUID = UUID.newBuilder().setMsb(uuidJava.mostSignificantBits)
-            .setLsb(uuidJava.leastSignificantBits).build()
+        val uuid: UUID = uUID {
+            msb = uuidJava.mostSignificantBits
+            lsb = uuidJava.leastSignificantBits
+        }
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
         val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withExtension("ttl", 3).withId(strUuid)
         val cloudEvent: CloudEvent = builder.build()
@@ -463,8 +458,7 @@ internal class UCloudEventTest {
         val cloudEventData: ByteArray = payloadForCloudEvent.toByteArray()
         val cloudEventBuilder: CloudEventBuilder = CloudEventBuilder.v1().withId("someId").withType("pub.v1")
             .withSource(URI.create("/body.access/1/door.front_left#Door")).withDataContentType(DATA_CONTENT_TYPE)
-            .withDataSchema(URI.create("type.googleapis.com/io.cloudevents.v1.CloudEvent"))
-            .withData(cloudEventData)
+            .withDataSchema(URI.create("type.googleapis.com/io.cloudevents.v1.CloudEvent")).withData(cloudEventData)
         val cloudEvent: CloudEvent = cloudEventBuilder.build()
         val data: CloudEventData? = cloudEvent.data
         val dataAsAny: Any = Any.parseFrom(data!!.toBytes())
@@ -523,8 +517,7 @@ internal class UCloudEventTest {
             .withDataSchema(URI.create(payloadForCloudEvent.typeUrl)).withData(cloudEventData)
         val cloudEvent: CloudEvent = cloudEventBuilder.build()
         val extracted: Optional<io.cloudevents.v1.proto.CloudEvent> = UCloudEvent.unpack(
-            cloudEvent,
-            io.cloudevents.v1.proto.CloudEvent::class.java
+            cloudEvent, io.cloudevents.v1.proto.CloudEvent::class.java
         )
         assertTrue(extracted.isPresent)
         val unpackedCE: io.cloudevents.v1.proto.CloudEvent = extracted.get()
@@ -543,8 +536,7 @@ internal class UCloudEventTest {
             .withData("<html><head></head><body><p>Hello</p></body></html>".toByteArray())
         val cloudEvent: CloudEvent = cloudEventBuilder.build()
         val extracted: Optional<io.cloudevents.v1.proto.CloudEvent> = UCloudEvent.unpack(
-            cloudEvent,
-            io.cloudevents.v1.proto.CloudEvent::class.java
+            cloudEvent, io.cloudevents.v1.proto.CloudEvent::class.java
         )
         assertTrue(extracted.isEmpty)
     }
@@ -557,8 +549,8 @@ internal class UCloudEventTest {
             buildBaseCloudEventBuilderForTest().withExtension("sink", URI.create(sinkForTest))
         val cloudEvent: CloudEvent = builder.build()
         val prettyPrint: String = UCloudEvent.toString(cloudEvent)
-        val expected = ("CloudEvent{id='testme', source='/body.access//door.front_left#Door', " + "sink='//bo"
-                + ".cloud/petapp/1/rpc.response', type='pub.v1'}")
+        val expected =
+            ("CloudEvent{id='testme', source='/body.access//door.front_left#Door', " + "sink='//bo" + ".cloud/petapp/1/rpc.response', type='pub.v1'}")
         assertEquals(expected, prettyPrint)
     }
 
@@ -578,6 +570,7 @@ internal class UCloudEventTest {
         val expected = "CloudEvent{id='testme', source='/body.access//door.front_left#Door', type='pub.v1'}"
         assertEquals(expected, prettyPrint)
     }
+
     @Test
     @DisplayName("Test the type for a publish message type")
     fun test_type_for_publish() {
@@ -606,28 +599,34 @@ internal class UCloudEventTest {
         val uCloudEventType = UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_UNSPECIFIED)
         assertTrue(uCloudEventType.isBlank())
     }
+
     private fun buildBaseCloudEventBuilderForTest(): CloudEventBuilder {
         // source
-        val uUri: UUri = UUri.newBuilder().setEntity(UEntity.newBuilder().setName("body.access"))
-            .setResource(UResource.newBuilder().setName("door").setInstance("front_left").setMessage("Door"))
-            .build()
+        val uUri: UUri = uUri {
+            entity = uEntity { name = "body.access" }
+            resource = uResource {
+                name = "door"
+                instance = "front_left"
+                message = "Door"
+            }
+        }
+
         val source: String = LongUriSerializer.instance().serialize(uUri)
 
         // fake payload
         val protoPayload = buildProtoPayloadForTest()
 
         // additional attributes
-        val uCloudEventAttributes: UCloudEventAttributes = UCloudEventAttributes.UCloudEventAttributesBuilder().withHash(
-            "somehash"
-        ).withPriority(UPriority.UPRIORITY_CS1).withTtl(3).withToken(
-            "someOAuthToken"
-        )
-            .build()
+        val uCloudEventAttributes: UCloudEventAttributes =
+            UCloudEventAttributes.UCloudEventAttributesBuilder().withHash(
+                "somehash"
+            ).withPriority(UPriority.UPRIORITY_CS1).withTtl(3).withToken(
+                "someOAuthToken"
+            ).build()
 
         // build the cloud event
         val cloudEventBuilder: CloudEventBuilder = CloudEventFactory.buildBaseCloudEvent(
-            "testme", source,
-            protoPayload.toByteArray(), protoPayload.typeUrl, uCloudEventAttributes
+            "testme", source, protoPayload.toByteArray(), protoPayload.typeUrl, uCloudEventAttributes
         )
         cloudEventBuilder.withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
         return cloudEventBuilder

--- a/src/test/kotlin/org/eclipse/uprotocol/cloudevent/serialize/CloudEventToProtobufSerializerTest.kt
+++ b/src/test/kotlin/org/eclipse/uprotocol/cloudevent/serialize/CloudEventToProtobufSerializerTest.kt
@@ -30,16 +30,17 @@ import org.eclipse.uprotocol.cloudevent.factory.CloudEventFactory
 import org.eclipse.uprotocol.cloudevent.factory.UCloudEvent
 import org.eclipse.uprotocol.uri.serializer.LongUriSerializer
 import org.eclipse.uprotocol.v1.*
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.net.URI
-import java.util.Objects
-import org.junit.jupiter.api.Assertions.*
+import java.util.*
 
 
 internal class CloudEventToProtobufSerializerTest {
     private val serializer: CloudEventSerializer = CloudEventToProtobufSerializer()
     private val protoContentType: String = CloudEventFactory.PROTOBUF_CONTENT_TYPE
+
     @Test
     @DisplayName("Test serialize and deserialize a CloudEvent to protobuf")
     fun test_serialize_and_desirialize_cloud_event_to_protobuf() {
@@ -51,15 +52,11 @@ internal class CloudEventToProtobufSerializerTest {
         val protoPayload = buildProtoPayloadForTest()
 
         // configure cloud event
-        val uCloudEventAttributes: UCloudEventAttributes = UCloudEventAttributes.UCloudEventAttributesBuilder()
-            .withHash("somehash")
-            .withPriority(UPriority.UPRIORITY_CS0)
-            .withTtl(3)
-            .build()
+        val uCloudEventAttributes: UCloudEventAttributes =
+            UCloudEventAttributes.UCloudEventAttributesBuilder().withHash("somehash")
+                .withPriority(UPriority.UPRIORITY_CS0).withTtl(3).build()
         val cloudEventBuilder: CloudEventBuilder = CloudEventFactory.buildBaseCloudEvent(
-            "hello", source,
-            protoPayload.toByteArray(), protoPayload.typeUrl,
-            uCloudEventAttributes
+            "hello", source, protoPayload.toByteArray(), protoPayload.typeUrl, uCloudEventAttributes
         )
         cloudEventBuilder.withType("pub.v1")
         val cloudEvent: CloudEvent = cloudEventBuilder.build()
@@ -79,19 +76,13 @@ internal class CloudEventToProtobufSerializerTest {
         val protoPayload = buildProtoPayloadForTest()
 
         // cloudevent
-        val cloudEventBuilder: CloudEventBuilder = CloudEventBuilder.v1()
-            .withId("hello")
-            .withType("pub.v1")
-            .withSource(URI.create("/body.access/1/door.front_left"))
-            .withDataContentType("application/protobuf")
-            .withDataSchema(URI.create(protoPayload.typeUrl))
-            .withData(protoPayload.toByteArray())
+        val cloudEventBuilder: CloudEventBuilder = CloudEventBuilder.v1().withId("hello").withType("pub.v1")
+            .withSource(URI.create("/body.access/1/door.front_left")).withDataContentType("application/protobuf")
+            .withDataSchema(URI.create(protoPayload.typeUrl)).withData(protoPayload.toByteArray())
         val cloudEvent: CloudEvent = cloudEventBuilder.build()
 
         // another cloudevent
-        val anotherCloudEvent: CloudEvent = cloudEventBuilder
-            .withType("file.v1")
-            .build()
+        val anotherCloudEvent: CloudEvent = cloudEventBuilder.withType("file.v1").build()
         val bytesCloudEvent: ByteArray = serializer.serialize(cloudEvent)
         val bytesAnotherCloudEvent: ByteArray = serializer.serialize(anotherCloudEvent)
         assertNotEquals(bytesCloudEvent, bytesAnotherCloudEvent)
@@ -105,13 +96,9 @@ internal class CloudEventToProtobufSerializerTest {
         val protoPayload = buildProtoPayloadForTest()
 
         // cloudevent
-        val cloudEventBuilder: CloudEventBuilder = CloudEventBuilder.v1()
-            .withId("hello")
-            .withType("pub.v1")
-            .withSource(URI.create("/body.access/1/door.front_left"))
-            .withDataContentType("application/protobuf")
-            .withDataSchema(URI.create(protoPayload.typeUrl))
-            .withData(protoPayload.toByteArray())
+        val cloudEventBuilder: CloudEventBuilder = CloudEventBuilder.v1().withId("hello").withType("pub.v1")
+            .withSource(URI.create("/body.access/1/door.front_left")).withDataContentType("application/protobuf")
+            .withDataSchema(URI.create(protoPayload.typeUrl)).withData(protoPayload.toByteArray())
         val cloudEvent: CloudEvent = cloudEventBuilder.build()
 
         // another cloudevent
@@ -136,18 +123,13 @@ internal class CloudEventToProtobufSerializerTest {
         val protoPayload = buildProtoPayloadForTest1()
 
         // additional attributes
-        val uCloudEventAttributes: UCloudEventAttributes = UCloudEventAttributes.UCloudEventAttributesBuilder()
-            .withHash("somehash")
-            .withPriority(UPriority.UPRIORITY_CS1)
-            .withTtl(3)
-            .withToken("someOAuthToken")
-            .build()
+        val uCloudEventAttributes: UCloudEventAttributes =
+            UCloudEventAttributes.UCloudEventAttributesBuilder().withHash("somehash")
+                .withPriority(UPriority.UPRIORITY_CS1).withTtl(3).withToken("someOAuthToken").build()
 
         // build the cloud event
         val cloudEventBuilder: CloudEventBuilder = CloudEventFactory.buildBaseCloudEvent(
-            "testme", source,
-            protoPayload.toByteArray(), protoPayload.typeUrl,
-            uCloudEventAttributes
+            "testme", source, protoPayload.toByteArray(), protoPayload.typeUrl, uCloudEventAttributes
         )
         cloudEventBuilder.withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
         val cloudEvent1: CloudEvent = cloudEventBuilder.build()
@@ -245,55 +227,44 @@ internal class CloudEventToProtobufSerializerTest {
         val ce2ExtensionNames: Set<String> = cloudEvent2.extensionNames
         assertEquals(ce1ExtensionNames.joinToString(","), ce2ExtensionNames.joinToString(","))
         assertArrayEquals(
-            Objects.requireNonNull(cloudEvent1.data).toBytes(),
-            Objects.requireNonNull(cloudEvent2.data).toBytes()
+            Objects.requireNonNull(cloudEvent1.data).toBytes(), Objects.requireNonNull(cloudEvent2.data).toBytes()
         )
         assertEquals(cloudEvent1, cloudEvent2)
     }
 
     private fun buildCloudEventForTest(): CloudEventBuilder {
-        return CloudEventBuilder.v1()
-            .withId("hello")
-            .withType("pub.v1")
-            .withSource(URI.create("//VCU.VIN/body.access"))
+        return CloudEventBuilder.v1().withId("hello").withType("pub.v1").withSource(URI.create("//VCU.VIN/body.access"))
     }
 
     private fun buildProtoPayloadForTest1(): Any {
-        val cloudEventProto: io.cloudevents.v1.proto.CloudEvent = io.cloudevents.v1.proto.CloudEvent.newBuilder()
-            .setSpecVersion("1.0")
-            .setId("hello")
-            .setSource("//VCU.VIN/body.access")
-            .setType("pub.v1")
-            .setProtoData(Any.newBuilder().build())
-            .build()
+        val cloudEventProto: io.cloudevents.v1.proto.CloudEvent =
+            io.cloudevents.v1.proto.CloudEvent.newBuilder().setSpecVersion("1.0").setId("hello")
+                .setSource("//VCU.VIN/body.access").setType("pub.v1").setProtoData(Any.newBuilder().build()).build()
         return Any.pack(cloudEventProto)
     }
 
     private fun buildUriForTest(): String {
-        val uri: UUri = UUri.newBuilder()
-            .setEntity(UEntity.newBuilder().setName("body.access"))
-            .setResource(
-                UResource.newBuilder()
-                    .setName("door")
-                    .setInstance("front_left")
-                    .setMessage("Door")
-            )
-            .build()
+        val uri: UUri = uUri {
+            entity = uEntity { name = "body.access" }
+            resource = uResource {
+                name = "door"
+                instance = "front_left"
+                message = "Door"
+            }
+        }
+
+
         return LongUriSerializer.instance().serialize(uri)
     }
 
     private fun buildProtoPayloadForTest(): Any {
-        val cloudEventProto: io.cloudevents.v1.proto.CloudEvent = io.cloudevents.v1.proto.CloudEvent.newBuilder()
-            .setSpecVersion("1.0")
-            .setId("hello")
-            .setSource("http://example.com")
-            .setType("example.demo")
-            .setProtoData(Any.newBuilder().build())
-            .putAttributes(
-                "ttl", io.cloudevents.v1.proto.CloudEvent.CloudEventAttributeValue.newBuilder()
-                    .setCeString("3").build()
-            )
-            .build()
+        val cloudEventProto: io.cloudevents.v1.proto.CloudEvent =
+            io.cloudevents.v1.proto.CloudEvent.newBuilder().setSpecVersion("1.0").setId("hello")
+                .setSource("http://example.com").setType("example.demo").setProtoData(Any.newBuilder().build())
+                .putAttributes(
+                    "ttl",
+                    io.cloudevents.v1.proto.CloudEvent.CloudEventAttributeValue.newBuilder().setCeString("3").build()
+                ).build()
         return Any.pack(cloudEventProto)
     }
 }

--- a/src/test/kotlin/org/eclipse/uprotocol/cloudevent/validate/CloudEventValidatorTest.kt
+++ b/src/test/kotlin/org/eclipse/uprotocol/cloudevent/validate/CloudEventValidatorTest.kt
@@ -31,11 +31,11 @@ import org.eclipse.uprotocol.uuid.factory.UuidFactory
 import org.eclipse.uprotocol.uuid.serializer.LongUuidSerializer
 import org.eclipse.uprotocol.v1.*
 import org.eclipse.uprotocol.validation.ValidationResult
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.net.URI
 import java.time.Instant
-import org.junit.jupiter.api.Assertions.*
 
 internal class CloudEventValidatorTest {
     @Test
@@ -52,8 +52,8 @@ internal class CloudEventValidatorTest {
     @Test
     @DisplayName("Test get a notification cloud event validator")
     fun test_get_a_notification_cloud_event_validator() {
-        val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withExtension("sink", "//bo.cloud/petapp")
-            .withType("pub.v1")
+        val builder: CloudEventBuilder =
+            buildBaseCloudEventBuilderForTest().withExtension("sink", "//bo.cloud/petapp").withType("pub.v1")
         val cloudEvent: CloudEvent = builder.build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.NOTIFICATION.validator()
         val status: UStatus = validator.validateType(cloudEvent).toStatus()
@@ -70,8 +70,7 @@ internal class CloudEventValidatorTest {
         val status: UStatus = validator.validateType(cloudEvent).toStatus()
         assertEquals(UCode.INVALID_ARGUMENT, status.code)
         assertEquals(
-            "Invalid CloudEvent type [res.v1]. CloudEvent of type Publish must have a type of 'pub.v1'",
-            status.message
+            "Invalid CloudEvent type [res.v1]. CloudEvent of type Publish must have a type of 'pub.v1'", status.message
         )
     }
 
@@ -84,8 +83,7 @@ internal class CloudEventValidatorTest {
         val status: UStatus = validator.validateType(cloudEvent).toStatus()
         assertEquals(UCode.INVALID_ARGUMENT, status.code)
         assertEquals(
-            "Invalid CloudEvent type [res.v1]. CloudEvent of type Publish must have a type of 'pub.v1'",
-            status.message
+            "Invalid CloudEvent type [res.v1]. CloudEvent of type Publish must have a type of 'pub.v1'", status.message
         )
     }
 
@@ -109,8 +107,7 @@ internal class CloudEventValidatorTest {
         val status: UStatus = validator.validateType(cloudEvent).toStatus()
         assertEquals(UCode.INVALID_ARGUMENT, status.code)
         assertEquals(
-            "Invalid CloudEvent type [pub.v1]. CloudEvent of type Request must have a type of 'req.v1'",
-            status.message
+            "Invalid CloudEvent type [pub.v1]. CloudEvent of type Request must have a type of 'req.v1'", status.message
         )
     }
 
@@ -134,8 +131,7 @@ internal class CloudEventValidatorTest {
         val status: UStatus = validator.validateType(cloudEvent).toStatus()
         assertEquals(UCode.INVALID_ARGUMENT, status.code)
         assertEquals(
-            "Invalid CloudEvent type [pub.v1]. CloudEvent of type Response must have a type of 'res.v1'",
-            status.message
+            "Invalid CloudEvent type [pub.v1]. CloudEvent of type Response must have a type of 'res.v1'", status.message
         )
     }
 
@@ -153,8 +149,9 @@ internal class CloudEventValidatorTest {
     fun validate_cloud_event_version_when_valid() {
         val uuid: UUID = UuidFactory.Factories.UPROTOCOL.factory().create()
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
-        val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
-            .withId(strUuid)
+        val builder: CloudEventBuilder =
+            buildBaseCloudEventBuilderForTest().withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
+                .withId(strUuid)
         val cloudEvent: CloudEvent = builder.build()
         val status: UStatus = CloudEventValidator.validateVersion(cloudEvent).toStatus()
         assertEquals(status, ValidationResult.STATUS_SUCCESS)
@@ -164,9 +161,10 @@ internal class CloudEventValidatorTest {
     @DisplayName("Test validate version when not valid")
     fun validate_cloud_event_version_when_not_valid() {
         val payloadForTest = buildProtoPayloadForTest()
-        val builder: CloudEventBuilder = CloudEventBuilder.v03().withId("id").withType("pub.v1")
-            .withSource(URI.create("/body.access")).withDataContentType("application/protobuf")
-            .withDataSchema(URI.create(payloadForTest.typeUrl)).withData(payloadForTest.toByteArray())
+        val builder: CloudEventBuilder =
+            CloudEventBuilder.v03().withId("id").withType("pub.v1").withSource(URI.create("/body.access"))
+                .withDataContentType("application/protobuf").withDataSchema(URI.create(payloadForTest.typeUrl))
+                .withData(payloadForTest.toByteArray())
         val cloudEvent: CloudEvent = builder.build()
         val status: UStatus = CloudEventValidator.validateVersion(cloudEvent).toStatus()
         assertEquals(UCode.INVALID_ARGUMENT, status.code)
@@ -178,8 +176,9 @@ internal class CloudEventValidatorTest {
     fun validate_cloud_event_id_when_valid() {
         val uuid: UUID = UuidFactory.Factories.UPROTOCOL.factory().create()
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
-        val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
-            .withId(strUuid)
+        val builder: CloudEventBuilder =
+            buildBaseCloudEventBuilderForTest().withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
+                .withId(strUuid)
         val cloudEvent: CloudEvent = builder.build()
         val status: UStatus = CloudEventValidator.validateId(cloudEvent).toStatus()
         assertEquals(status, ValidationResult.STATUS_SUCCESS)
@@ -189,25 +188,28 @@ internal class CloudEventValidatorTest {
     @DisplayName("Test validate cloudevent id when not UUIDv8 type id")
     fun validate_cloud_event_id_when_not_uuidv6_type_id() {
         val uuidJava: java.util.UUID = java.util.UUID.randomUUID()
-        val uuid: UUID = UUID.newBuilder().setMsb(uuidJava.mostSignificantBits)
-            .setLsb(uuidJava.leastSignificantBits).build()
+        val uuid: UUID = uUID {
+            msb = uuidJava.mostSignificantBits
+            lsb = uuidJava.leastSignificantBits
+        }
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
-        val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
-            .withId(strUuid)
+        val builder: CloudEventBuilder =
+            buildBaseCloudEventBuilderForTest().withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
+                .withId(strUuid)
         val cloudEvent: CloudEvent = builder.build()
         val status: UStatus = CloudEventValidator.validateId(cloudEvent).toStatus()
         assertEquals(UCode.INVALID_ARGUMENT, status.code)
         assertEquals(
-            "Invalid CloudEvent Id [$strUuid]. CloudEvent Id must be of type UUIDv8.",
-            status.message
+            "Invalid CloudEvent Id [$strUuid]. CloudEvent Id must be of type UUIDv8.", status.message
         )
     }
 
     @Test
     @DisplayName("Test validate cloudevent id when not valid")
     fun validate_cloud_event_id_when_not_valid() {
-        val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
-            .withId("testme")
+        val builder: CloudEventBuilder =
+            buildBaseCloudEventBuilderForTest().withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
+                .withId("testme")
         val cloudEvent: CloudEvent = builder.build()
         val status: UStatus = CloudEventValidator.validateId(cloudEvent).toStatus()
         assertEquals(UCode.INVALID_ARGUMENT, status.code)
@@ -220,7 +222,8 @@ internal class CloudEventValidatorTest {
         val uuid: UUID = UuidFactory.Factories.UPROTOCOL.factory().create()
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
         val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withId(strUuid)
-            .withSource(URI.create("/body.access/1/door.front_left#Door")).withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
+            .withSource(URI.create("/body.access/1/door.front_left#Door"))
+            .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
         val cloudEvent: CloudEvent = builder.build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.PUBLISH.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
@@ -248,7 +251,8 @@ internal class CloudEventValidatorTest {
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
         val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withId(strUuid)
             .withSource(URI.create("//VCU.myvin/body.access/1/door.front_left#Door"))
-            .withExtension("sink", "//bo.cloud/petapp").withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
+            .withExtension("sink", "//bo.cloud/petapp")
+            .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
         val cloudEvent: CloudEvent = builder.build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.PUBLISH.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
@@ -267,8 +271,7 @@ internal class CloudEventValidatorTest {
         val validator: CloudEventValidator = CloudEventValidator.Validators.PUBLISH.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
         assertEquals(
-            "Invalid CloudEvent sink [//bo.cloud]. Uri is missing uSoftware Entity name.",
-            result.getMessage()
+            "Invalid CloudEvent sink [//bo.cloud]. Uri is missing uSoftware Entity name.", result.getMessage()
         )
     }
 
@@ -277,8 +280,8 @@ internal class CloudEventValidatorTest {
     fun test_publish_type_cloudevent_is_not_valid_when_source_is_empty() {
         val uuid: UUID = UuidFactory.Factories.UPROTOCOL.factory().create()
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
-        val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withId(strUuid)
-            .withSource(URI.create("/")).withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
+        val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withId(strUuid).withSource(URI.create("/"))
+            .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
         val cloudEvent: CloudEvent = builder.build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.PUBLISH.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
@@ -288,14 +291,14 @@ internal class CloudEventValidatorTest {
     @Test
     @DisplayName("Test Publish type CloudEvent is not valid when source is invalid and id invalid")
     fun test_publish_type_cloudevent_is_not_valid_when_source_is_missing_authority() {
-        val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withId("testme")
-            .withSource(URI.create("/body.access")).withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
+        val builder: CloudEventBuilder =
+            buildBaseCloudEventBuilderForTest().withId("testme").withSource(URI.create("/body.access"))
+                .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
         val cloudEvent: CloudEvent = builder.build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.PUBLISH.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
         assertEquals(
-            "Invalid CloudEvent Id [testme]. CloudEvent Id must be of type UUIDv8.," + "Invalid Publish type " +
-                    "CloudEvent source [/body.access]. UriPart is missing uResource name.",
+            "Invalid CloudEvent Id [testme]. CloudEvent Id must be of type UUIDv8.," + "Invalid Publish type " + "CloudEvent source [/body.access]. UriPart is missing uResource name.",
             result.getMessage()
         )
     }
@@ -304,13 +307,13 @@ internal class CloudEventValidatorTest {
     @DisplayName("Test Publish type CloudEvent is not valid when source is invalid missing message information")
     fun test_publish_type_cloudevent_is_not_valid_when_source_is_missing_message_info() {
         val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withId("testme")
-            .withSource(URI.create("/body.access/1/door.front_left")).withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
+            .withSource(URI.create("/body.access/1/door.front_left"))
+            .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
         val cloudEvent: CloudEvent = builder.build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.PUBLISH.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
         assertEquals(
-            "Invalid CloudEvent Id [testme]. CloudEvent Id must be of type UUIDv8.," + "Invalid Publish type " +
-                    "CloudEvent source [/body.access/1/door.front_left]. UriPart is missing Message information.",
+            "Invalid CloudEvent Id [testme]. CloudEvent Id must be of type UUIDv8.," + "Invalid Publish type " + "CloudEvent source [/body.access/1/door.front_left]. UriPart is missing Message information.",
             result.getMessage()
         )
     }
@@ -321,7 +324,8 @@ internal class CloudEventValidatorTest {
         val uuid: UUID = UuidFactory.Factories.UPROTOCOL.factory().create()
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
         val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withId(strUuid)
-            .withSource(URI.create("/body.access/1/door.front_left#Door")).withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
+            .withSource(URI.create("/body.access/1/door.front_left#Door"))
+            .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
             .withExtension("sink", "//bo.cloud/petapp")
         val cloudEvent: CloudEvent = builder.build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.NOTIFICATION.validator()
@@ -335,7 +339,8 @@ internal class CloudEventValidatorTest {
         val uuid: UUID = UuidFactory.Factories.UPROTOCOL.factory().create()
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
         val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withId(strUuid)
-            .withSource(URI.create("/body.access/1/door.front_left#Door")).withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
+            .withSource(URI.create("/body.access/1/door.front_left#Door"))
+            .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
         val cloudEvent: CloudEvent = builder.build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.NOTIFICATION.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
@@ -348,8 +353,8 @@ internal class CloudEventValidatorTest {
         val uuid: UUID = UuidFactory.Factories.UPROTOCOL.factory().create()
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
         val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withId(strUuid)
-            .withSource(URI.create("/body.access/1/door.front_left#Door")).withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
-            .withExtension("sink", "//bo.cloud")
+            .withSource(URI.create("/body.access/1/door.front_left#Door"))
+            .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH)).withExtension("sink", "//bo.cloud")
         val cloudEvent: CloudEvent = builder.build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.NOTIFICATION.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
@@ -365,7 +370,8 @@ internal class CloudEventValidatorTest {
         val uuid: UUID = UuidFactory.Factories.UPROTOCOL.factory().create()
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
         val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withId(strUuid)
-            .withSource(URI.create("//bo.cloud/petapp//rpc.response")).withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_REQUEST))
+            .withSource(URI.create("//bo.cloud/petapp//rpc.response"))
+            .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_REQUEST))
             .withExtension("sink", "//VCU.myvin/body.access/1/rpc.UpdateDoor")
         val cloudEvent: CloudEvent = builder.build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.REQUEST.validator()
@@ -378,16 +384,15 @@ internal class CloudEventValidatorTest {
     fun test_request_type_cloudevent_is_not_valid_invalid_source() {
         val uuid: UUID = UuidFactory.Factories.UPROTOCOL.factory().create()
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
-        val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withId(strUuid)
-            .withSource(URI.create("//bo.cloud/petapp//dog"))
-            .withExtension("sink", "//VCU.myvin/body.access/1/rpc.UpdateDoor")
-            .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_REQUEST))
+        val builder: CloudEventBuilder =
+            buildBaseCloudEventBuilderForTest().withId(strUuid).withSource(URI.create("//bo.cloud/petapp//dog"))
+                .withExtension("sink", "//VCU.myvin/body.access/1/rpc.UpdateDoor")
+                .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_REQUEST))
         val cloudEvent: CloudEvent = builder.build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.REQUEST.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
         assertEquals(
-            "Invalid RPC Request CloudEvent source [//bo.cloud/petapp//dog]. " + "Invalid RPC uri application " +
-                    "response topic. UriPart is missing rpc.response.",
+            "Invalid RPC Request CloudEvent source [//bo.cloud/petapp//dog]. " + "Invalid RPC uri application " + "response topic. UriPart is missing rpc.response.",
             result.getMessage()
         )
     }
@@ -398,7 +403,8 @@ internal class CloudEventValidatorTest {
         val uuid: UUID = UuidFactory.Factories.UPROTOCOL.factory().create()
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
         val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withId(strUuid)
-            .withSource(URI.create("//bo.cloud/petapp//rpc.response")).withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_REQUEST))
+            .withSource(URI.create("//bo.cloud/petapp//rpc.response"))
+            .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_REQUEST))
         val cloudEvent: CloudEvent = builder.build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.REQUEST.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
@@ -414,14 +420,14 @@ internal class CloudEventValidatorTest {
         val uuid: UUID = UuidFactory.Factories.UPROTOCOL.factory().create()
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
         val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withId(strUuid)
-            .withSource(URI.create("//bo.cloud/petapp//rpc.response")).withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_REQUEST))
+            .withSource(URI.create("//bo.cloud/petapp//rpc.response"))
+            .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_REQUEST))
             .withExtension("sink", "//VCU.myvin/body.access/1/UpdateDoor")
         val cloudEvent: CloudEvent = builder.build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.REQUEST.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
         assertEquals(
-            "Invalid RPC Request CloudEvent sink [//VCU.myvin/body.access/1/UpdateDoor]. " + "Invalid RPC method " +
-                    "uri. UriPart should be the method to be called, or method from response.",
+            "Invalid RPC Request CloudEvent sink [//VCU.myvin/body.access/1/UpdateDoor]. " + "Invalid RPC method " + "uri. UriPart should be the method to be called, or method from response.",
             result.getMessage()
         )
     }
@@ -433,7 +439,8 @@ internal class CloudEventValidatorTest {
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
         val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withId(strUuid)
             .withSource(URI.create("//VCU.myvin/body.access/1/rpc.UpdateDoor"))
-            .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_RESPONSE)).withExtension("sink", "//bo.cloud/petapp//rpc.response")
+            .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_RESPONSE))
+            .withExtension("sink", "//bo.cloud/petapp//rpc.response")
         val cloudEvent: CloudEvent = builder.build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.RESPONSE.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
@@ -447,13 +454,13 @@ internal class CloudEventValidatorTest {
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
         val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withId(strUuid)
             .withSource(URI.create("//VCU.myvin/body.access/1/UpdateDoor"))
-            .withExtension("sink", "//bo.cloud/petapp//rpc.response").withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_RESPONSE))
+            .withExtension("sink", "//bo.cloud/petapp//rpc.response")
+            .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_RESPONSE))
         val cloudEvent: CloudEvent = builder.build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.RESPONSE.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
         assertEquals(
-            "Invalid RPC Response CloudEvent source [//VCU.myvin/body.access/1/UpdateDoor]. " + "Invalid RPC " +
-                    "method uri. UriPart should be the method to be called, or method from response.",
+            "Invalid RPC Response CloudEvent source [//VCU.myvin/body.access/1/UpdateDoor]. " + "Invalid RPC " + "method uri. UriPart should be the method to be called, or method from response.",
             result.getMessage()
         )
     }
@@ -470,9 +477,7 @@ internal class CloudEventValidatorTest {
         val validator: CloudEventValidator = CloudEventValidator.Validators.RESPONSE.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
         assertEquals(
-            "Invalid RPC Response CloudEvent source [//VCU.myvin/body.access/1/UpdateDoor]. " + "Invalid RPC " +
-                    "method uri. UriPart should be the method to be called, or method from response.," + "Invalid" +
-                    " CloudEvent sink. Response CloudEvent sink must be uri the destination of the response.",
+            "Invalid RPC Response CloudEvent source [//VCU.myvin/body.access/1/UpdateDoor]. " + "Invalid RPC " + "method uri. UriPart should be the method to be called, or method from response.," + "Invalid" + " CloudEvent sink. Response CloudEvent sink must be uri the destination of the response.",
             result.getMessage()
         )
     }
@@ -483,15 +488,13 @@ internal class CloudEventValidatorTest {
         val uuid: UUID = UuidFactory.Factories.UPROTOCOL.factory().create()
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
         val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withId(strUuid)
-            .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_RESPONSE)).withSource(URI.create("//VCU.myvin"))
-            .withExtension("sink", "//bo.cloud")
+            .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_RESPONSE))
+            .withSource(URI.create("//VCU.myvin")).withExtension("sink", "//bo.cloud")
         val cloudEvent: CloudEvent = builder.build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.RESPONSE.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
         assertEquals(
-            "Invalid RPC Response CloudEvent source [//VCU.myvin]. Invalid RPC method uri. Uri is missing " +
-                    "uSoftware Entity name.,Invalid RPC Response CloudEvent sink [//bo.cloud]. Invalid RPC uri " +
-                    "application response topic. Uri is missing uSoftware Entity name.",
+            "Invalid RPC Response CloudEvent source [//VCU.myvin]. Invalid RPC method uri. Uri is missing " + "uSoftware Entity name.,Invalid RPC Response CloudEvent sink [//bo.cloud]. Invalid RPC uri " + "application response topic. Uri is missing uSoftware Entity name.",
             result.getMessage()
         )
     }
@@ -501,17 +504,15 @@ internal class CloudEventValidatorTest {
     fun test_response_type_cloudevent_is_not_valid_invalid_source_not_rpc_command() {
         val uuid: UUID = UuidFactory.Factories.UPROTOCOL.factory().create()
         val strUuid = LongUuidSerializer.instance().serialize(uuid)
-        val builder: CloudEventBuilder = buildBaseCloudEventBuilderForTest().withId(strUuid)
-            .withSource(URI.create("//bo.cloud/petapp/1/dog")).withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_RESPONSE))
-            .withExtension("sink", "//VCU.myvin/body.access/1/UpdateDoor")
+        val builder: CloudEventBuilder =
+            buildBaseCloudEventBuilderForTest().withId(strUuid).withSource(URI.create("//bo.cloud/petapp/1/dog"))
+                .withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_RESPONSE))
+                .withExtension("sink", "//VCU.myvin/body.access/1/UpdateDoor")
         val cloudEvent: CloudEvent = builder.build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.RESPONSE.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
         assertEquals(
-            "Invalid RPC Response CloudEvent source [//bo.cloud/petapp/1/dog]. Invalid RPC method uri. UriPart " +
-                    "should be the method to be called, or method from response.," + "Invalid RPC Response " +
-                    "CloudEvent sink [//VCU.myvin/body.access/1/UpdateDoor]. " + "Invalid RPC uri application " +
-                    "response topic. UriPart is missing rpc.response.",
+            "Invalid RPC Response CloudEvent source [//bo.cloud/petapp/1/dog]. Invalid RPC method uri. UriPart " + "should be the method to be called, or method from response.," + "Invalid RPC Response " + "CloudEvent sink [//VCU.myvin/body.access/1/UpdateDoor]. " + "Invalid RPC uri application " + "response topic. UriPart is missing rpc.response.",
             result.getMessage()
         )
     }
@@ -524,26 +525,25 @@ internal class CloudEventValidatorTest {
         val protoPayload = buildProtoPayloadForTest()
 
         // additional attributes
-        val uCloudEventAttributes: UCloudEventAttributes = UCloudEventAttributes.UCloudEventAttributesBuilder().withHash(
-            "somehash"
-        ).withPriority(UPriority.UPRIORITY_CS1).withTtl(3).withToken(
-            "someOAuthToken"
-        )
-            .build()
+        val uCloudEventAttributes: UCloudEventAttributes =
+            UCloudEventAttributes.UCloudEventAttributesBuilder().withHash(
+                "somehash"
+            ).withPriority(UPriority.UPRIORITY_CS1).withTtl(3).withToken(
+                "someOAuthToken"
+            ).build()
 
         // build the cloud event
         val cloudEventBuilder: CloudEventBuilder = CloudEventFactory.buildBaseCloudEvent(
-            "testme", source,
-            protoPayload.toByteArray(), protoPayload.typeUrl, uCloudEventAttributes
+            "testme", source, protoPayload.toByteArray(), protoPayload.typeUrl, uCloudEventAttributes
         )
         cloudEventBuilder.withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH))
         return cloudEventBuilder
     }
 
     private fun buildProtoPayloadForTest(): Any {
-        val cloudEventProto: io.cloudevents.v1.proto.CloudEvent = io.cloudevents.v1.proto.CloudEvent.newBuilder()
-            .setSpecVersion("1.0").setId("hello").setSource("/body.access").setType("example.demo")
-            .setProtoData(Any.newBuilder().build()).build()
+        val cloudEventProto: io.cloudevents.v1.proto.CloudEvent =
+            io.cloudevents.v1.proto.CloudEvent.newBuilder().setSpecVersion("1.0").setId("hello")
+                .setSource("/body.access").setType("example.demo").setProtoData(Any.newBuilder().build()).build()
         return Any.pack(cloudEventProto)
     }
 
@@ -565,8 +565,7 @@ internal class CloudEventValidatorTest {
 
         // build the cloud event
         val cloudEvent: CloudEvent = CloudEventFactory.buildBaseCloudEvent(
-            id, source, protoPayload.toByteArray(),
-            protoPayload.typeUrl, attributes
+            id, source, protoPayload.toByteArray(), protoPayload.typeUrl, attributes
         ).withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH)).build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.PUBLISH.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
@@ -592,8 +591,7 @@ internal class CloudEventValidatorTest {
 
         // build the cloud event
         val cloudEvent: CloudEvent = CloudEventFactory.buildBaseCloudEvent(
-            id, source, protoPayload.toByteArray(),
-            protoPayload.typeUrl, attributes
+            id, source, protoPayload.toByteArray(), protoPayload.typeUrl, attributes
         ).withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH)).build()
         val validator: CloudEventValidator = CloudEventValidator.Validators.PUBLISH.validator()
         val result: ValidationResult = validator.validate(cloudEvent)
@@ -606,8 +604,14 @@ internal class CloudEventValidatorTest {
     }
 
     private fun buildUUriForTest(): UUri {
-        return UUri.newBuilder().setEntity(UEntity.newBuilder().setName("body.access"))
-            .setResource(UResource.newBuilder().setName("door").setInstance("front_left").setMessage("Door"))
-            .build()
+        return uUri {
+            entity = uEntity { name = "body.access" }
+            resource = uResource {
+                name = "door"
+                instance = "front_left"
+                message = "Door"
+            }
+        }
+
     }
 }

--- a/src/test/kotlin/org/eclipse/uprotocol/cloudevent/validate/ValidationResultTest.kt
+++ b/src/test/kotlin/org/eclipse/uprotocol/cloudevent/validate/ValidationResultTest.kt
@@ -23,10 +23,11 @@ package org.eclipse.uprotocol.cloudevent.validate
 
 import org.eclipse.uprotocol.v1.UCode
 import org.eclipse.uprotocol.v1.UStatus
+import org.eclipse.uprotocol.v1.uStatus
+import org.eclipse.uprotocol.validation.ValidationResult
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Assertions.*
-import org.eclipse.uprotocol.validation.ValidationResult
 
 internal class ValidationResultTest {
     @Test
@@ -82,7 +83,10 @@ internal class ValidationResultTest {
     @DisplayName("Test failure toStatus")
     fun test_failure_validation_result_toStatus() {
         val failure: ValidationResult = ValidationResult.failure("boom")
-        val status: UStatus = UStatus.newBuilder().setCode(UCode.INVALID_ARGUMENT).setMessage("boom").build()
+        val status: UStatus = uStatus {
+            code = UCode.INVALID_ARGUMENT
+            message = "boom"
+        }
         assertEquals(status, failure.toStatus())
     }
 }

--- a/src/test/kotlin/org/eclipse/uprotocol/rpc/RpcResultTest.kt
+++ b/src/test/kotlin/org/eclipse/uprotocol/rpc/RpcResultTest.kt
@@ -23,6 +23,7 @@ package org.eclipse.uprotocol.rpc
 
 import org.eclipse.uprotocol.v1.UCode
 import org.eclipse.uprotocol.v1.UStatus
+import org.eclipse.uprotocol.v1.uStatus
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
@@ -99,7 +100,10 @@ internal class RpcResultTest {
     fun testFailureValue_onFailure_() {
         val result: RpcResult<Int> = RpcResult.failure(UCode.INVALID_ARGUMENT, "boom")
         val resultValue: UStatus = result.failureValue
-        assertEquals(UStatus.newBuilder().setCode(UCode.INVALID_ARGUMENT).setMessage("boom").build(), resultValue)
+        assertEquals(uStatus {
+            code = UCode.INVALID_ARGUMENT
+            message = "boom"
+        }, resultValue)
     }
 
     private val default: Int
@@ -133,7 +137,10 @@ internal class RpcResultTest {
         val result: RpcResult<Int> = RpcResult.failure(UCode.INVALID_ARGUMENT, "boom")
         val mapped: RpcResult<Int> = result.map { x -> x * 2 }
         assertTrue(mapped.isFailure)
-        assertEquals(UStatus.newBuilder().setCode(UCode.INVALID_ARGUMENT).setMessage("boom").build(), mapped.failureValue)
+        assertEquals(uStatus {
+            code = UCode.INVALID_ARGUMENT
+            message = "boom"
+        }, mapped.failureValue)
     }
 
     @Test
@@ -162,7 +169,10 @@ internal class RpcResultTest {
         val result: RpcResult<Int> = RpcResult.failure(UCode.INVALID_ARGUMENT, "boom")
         val flatMapped: RpcResult<Int> = result.flatMap { x -> RpcResult.success(x * 2) }
         assertTrue(flatMapped.isFailure)
-        assertEquals(UStatus.newBuilder().setCode(UCode.INVALID_ARGUMENT).setMessage("boom").build(), flatMapped.failureValue)
+        assertEquals(uStatus {
+            code = UCode.INVALID_ARGUMENT
+            message = "boom"
+        }, flatMapped.failureValue)
     }
 
     @Test
@@ -170,7 +180,10 @@ internal class RpcResultTest {
         val result: RpcResult<Int> = RpcResult.success(2)
         val filterResult: RpcResult<Int> = result.filter { i -> i > 5 }
         assertTrue(filterResult.isFailure)
-        assertEquals(UStatus.newBuilder().setCode(UCode.FAILED_PRECONDITION).setMessage("filtered out").build(), filterResult.failureValue)
+        assertEquals(uStatus {
+            code = UCode.FAILED_PRECONDITION
+            message = "filtered out"
+        }, filterResult.failureValue)
     }
 
     @Test
@@ -186,7 +199,10 @@ internal class RpcResultTest {
         val result: RpcResult<Int> = RpcResult.success(2)
         val filterResult: RpcResult<Int> = result.filter { x: Int -> predicateThatThrowsAnException(x) }
         assertTrue(filterResult.isFailure)
-        assertEquals(UStatus.newBuilder().setCode(UCode.UNKNOWN).setMessage("2 went boom").build(), filterResult.failureValue)
+        assertEquals(uStatus {
+            code = UCode.UNKNOWN
+            message = "2 went boom"
+        }, filterResult.failureValue)
     }
 
     private fun predicateThatThrowsAnException(x: Int): Boolean {
@@ -198,7 +214,10 @@ internal class RpcResultTest {
         val result: RpcResult<Int> = RpcResult.failure(UCode.INVALID_ARGUMENT, "boom")
         val filterResult: RpcResult<Int> = result.filter { i -> i > 5 }
         assertTrue(filterResult.isFailure)
-        assertEquals(UStatus.newBuilder().setCode(UCode.INVALID_ARGUMENT).setMessage("boom").build(), filterResult.failureValue)
+        assertEquals(uStatus {
+            code = UCode.INVALID_ARGUMENT
+            message = "boom"
+        }, filterResult.failureValue)
     }
 
     @Test
@@ -226,7 +245,10 @@ internal class RpcResultTest {
         val mapped: RpcResult<RpcResult<Int>> = result.map { x: Int -> multiplyBy2(x) }
         val mappedFlattened: RpcResult<Int> = RpcResult.flatten(mapped)
         assertTrue(mappedFlattened.isFailure)
-        assertEquals(UStatus.newBuilder().setCode(UCode.INVALID_ARGUMENT).setMessage("boom").build(), mappedFlattened.failureValue)
+        assertEquals(uStatus {
+            code = UCode.INVALID_ARGUMENT
+            message = "boom"
+        }, mappedFlattened.failureValue)
     }
 
     private fun multiplyBy2(x: Int): RpcResult<Int> {
@@ -242,11 +264,13 @@ internal class RpcResultTest {
     @Test
     fun testToStringFailure() {
         val result: RpcResult<Int> = RpcResult.failure(UCode.INVALID_ARGUMENT, "boom")
-        assertEquals("""
+        assertEquals(
+            """
     Failure(code: INVALID_ARGUMENT
     message: "boom"
     )
-    """.trimIndent(), result.toString())
+    """.trimIndent(), result.toString()
+        )
     }
 
 }

--- a/src/test/kotlin/org/eclipse/uprotocol/transport/builder/UAttributesBuilderTest.kt
+++ b/src/test/kotlin/org/eclipse/uprotocol/transport/builder/UAttributesBuilderTest.kt
@@ -22,9 +22,9 @@ package org.eclipse.uprotocol.transport.builder
 
 import org.eclipse.uprotocol.uri.builder.UResourceBuilder
 import org.eclipse.uprotocol.v1.*
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
 
 
 class UAttributesBuilderTest {
@@ -97,16 +97,23 @@ class UAttributesBuilderTest {
     }
 
     private fun buildSink(): UUri {
-        return UUri.newBuilder().setAuthority(UAuthority.newBuilder().setName("vcu.someVin.veh.ultifi.gm.com"))
-            .setEntity(UEntity.newBuilder().setName("petapp.ultifi.gm.com").setVersionMajor(1))
-            .setResource(UResourceBuilder.forRpcResponse()).build()
+        return uUri {
+            authority = uAuthority { name = "vcu.someVin.veh.ultifi.gm.com" }
+            entity = uEntity {
+                name = "petapp.ultifi.gm.com"
+                versionMajor = 1
+            }
+            resource = UResourceBuilder.forRpcResponse()
+        }
+
     }
 
     private val uUID: UUID
         get() {
             val uuidJava: java.util.UUID = java.util.UUID.randomUUID()
-            return UUID.newBuilder().setMsb(uuidJava.mostSignificantBits)
-                .setLsb(uuidJava.leastSignificantBits)
-                .build()
+            return uUID {
+                msb = uuidJava.mostSignificantBits
+                lsb = uuidJava.leastSignificantBits
+            }
         }
 }

--- a/src/test/kotlin/org/eclipse/uprotocol/transport/validator/UAttributesValidatorTest.kt
+++ b/src/test/kotlin/org/eclipse/uprotocol/transport/validator/UAttributesValidatorTest.kt
@@ -27,10 +27,10 @@ import org.eclipse.uprotocol.uri.serializer.LongUriSerializer
 import org.eclipse.uprotocol.uuid.factory.UuidFactory
 import org.eclipse.uprotocol.v1.*
 import org.eclipse.uprotocol.validation.ValidationResult
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
 
 internal class UAttributesValidatorTest {
@@ -42,13 +42,12 @@ internal class UAttributesValidatorTest {
         )
         assertEquals("UAttributesValidator.Publish", publish.toString())
         val request: UAttributesValidator = UAttributesValidator.getValidator(
-            UAttributesBuilder.request(UPriority.UPRIORITY_CS4, UUri.newBuilder().build(), 1000).build()
+            UAttributesBuilder.request(UPriority.UPRIORITY_CS4, uUri { }, 1000).build()
         )
         assertEquals("UAttributesValidator.Request", request.toString())
         val response: UAttributesValidator = UAttributesValidator.getValidator(
             UAttributesBuilder.response(
-                UPriority.UPRIORITY_CS4, UUri.newBuilder().build(),
-                UuidFactory.Factories.UPROTOCOL.factory().create()
+                UPriority.UPRIORITY_CS4, uUri { }, UuidFactory.Factories.UPROTOCOL.factory().create()
             ).build()
         )
         assertEquals("UAttributesValidator.Response", response.toString())
@@ -81,8 +80,7 @@ internal class UAttributesValidatorTest {
     @DisplayName("Validate a UAttributes for payload that is meant to be published with invalid type")
     fun test_validate_uAttributes_for_publish_message_payload_invalid_type() {
         val attributes: UAttributes = UAttributesBuilder.response(
-            UPriority.UPRIORITY_CS0, buildSink(),
-            UuidFactory.Factories.UPROTOCOL.factory().create()
+            UPriority.UPRIORITY_CS0, buildSink(), UuidFactory.Factories.UPROTOCOL.factory().create()
         ).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.PUBLISH.validator()
         val status: ValidationResult = validator.validate(attributes)
@@ -104,8 +102,7 @@ internal class UAttributesValidatorTest {
     @DisplayName("Validate a UAttributes for payload that is meant to be published with invalid sink")
     fun test_validate_uAttributes_for_publish_message_payload_invalid_sink() {
         val attributes: UAttributes =
-            UAttributesBuilder.publish(UPriority.UPRIORITY_CS0).withSink(UUri.getDefaultInstance())
-                .build()
+            UAttributesBuilder.publish(UPriority.UPRIORITY_CS0).withSink(UUri.getDefaultInstance()).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.PUBLISH.validator()
         val status: ValidationResult = validator.validate(attributes)
         assertTrue(status.isFailure())
@@ -137,10 +134,10 @@ internal class UAttributesValidatorTest {
     @DisplayName("Validate a UAttributes for payload that is meant to be published with invalid request id")
     fun test_validate_uAttributes_for_publish_message_payload_invalid_request_id() {
         val uuidJava: java.util.UUID = java.util.UUID.randomUUID()
-        val attributes: UAttributes = UAttributesBuilder.publish(UPriority.UPRIORITY_CS0).withReqId(
-            UUID.newBuilder().setMsb(uuidJava.mostSignificantBits).setLsb(uuidJava.leastSignificantBits)
-                .build()
-        ).build()
+        val attributes: UAttributes = UAttributesBuilder.publish(UPriority.UPRIORITY_CS0).withReqId(uUID {
+            msb = uuidJava.mostSignificantBits
+            lsb = uuidJava.leastSignificantBits
+        }).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.PUBLISH.validator()
         val status: ValidationResult = validator.validate(attributes)
         assertTrue(status.isFailure())
@@ -161,9 +158,9 @@ internal class UAttributesValidatorTest {
     @Test
     @DisplayName("Validate a UAttributes for payload that is meant to be an RPC request with all values")
     fun test_validate_uAttributes_for_rpc_request_message_payload_all_values() {
-        val attributes: UAttributes = UAttributesBuilder.request(UPriority.UPRIORITY_CS4, buildSink(), 1000)
-            .withPermissionLevel(2).withCommStatus(3).withReqId(UuidFactory.Factories.UPROTOCOL.factory().create())
-            .build()
+        val attributes: UAttributes =
+            UAttributesBuilder.request(UPriority.UPRIORITY_CS4, buildSink(), 1000).withPermissionLevel(2)
+                .withCommStatus(3).withReqId(UuidFactory.Factories.UPROTOCOL.factory().create()).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.REQUEST.validator()
         val status: ValidationResult = validator.validate(attributes)
         assertTrue(status.isSuccess())
@@ -174,8 +171,7 @@ internal class UAttributesValidatorTest {
     @DisplayName("Validate a UAttributes for payload that is meant to be an RPC request with invalid type")
     fun test_validate_uAttributes_for_rpc_request_message_payload_invalid_type() {
         val attributes: UAttributes = UAttributesBuilder.response(
-            UPriority.UPRIORITY_CS4, buildSink(),
-            UuidFactory.Factories.UPROTOCOL.factory().create()
+            UPriority.UPRIORITY_CS4, buildSink(), UuidFactory.Factories.UPROTOCOL.factory().create()
         ).withTtl(1000).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.REQUEST.validator()
         val status: ValidationResult = validator.validate(attributes)
@@ -197,8 +193,7 @@ internal class UAttributesValidatorTest {
     @DisplayName("Validate a UAttributes for payload that is meant to be an RPC request with invalid sink")
     fun test_validate_uAttributes_for_rpc_request_message_payload_invalid_sink() {
         val attributes: UAttributes =
-            UAttributesBuilder.request(UPriority.UPRIORITY_CS4, UUri.getDefaultInstance(), 1000)
-                .build()
+            UAttributesBuilder.request(UPriority.UPRIORITY_CS4, UUri.getDefaultInstance(), 1000).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.REQUEST.validator()
         val status: ValidationResult = validator.validate(attributes)
         assertTrue(status.isFailure())
@@ -208,8 +203,8 @@ internal class UAttributesValidatorTest {
     @Test
     @DisplayName("Validate a UAttributes for payload that is meant to be an RPC request with invalid permission level")
     fun test_validate_uAttributes_for_rpc_request_message_payload_invalid_permission_level() {
-        val attributes: UAttributes = UAttributesBuilder.request(UPriority.UPRIORITY_CS4, buildSink(), 1000)
-            .withPermissionLevel(-42).build()
+        val attributes: UAttributes =
+            UAttributesBuilder.request(UPriority.UPRIORITY_CS4, buildSink(), 1000).withPermissionLevel(-42).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.REQUEST.validator()
         val status: ValidationResult = validator.validate(attributes)
         assertTrue(status.isFailure())
@@ -220,8 +215,7 @@ internal class UAttributesValidatorTest {
     @DisplayName("Validate a UAttributes for payload that is meant to be an RPC request with invalid communication " + "status")
     fun test_validate_uAttributes_for_rpc_request_message_payload_invalid_communication_status() {
         val attributes: UAttributes =
-            UAttributesBuilder.request(UPriority.UPRIORITY_CS4, buildSink(), 1000).withCommStatus(-42)
-                .build()
+            UAttributesBuilder.request(UPriority.UPRIORITY_CS4, buildSink(), 1000).withCommStatus(-42).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.REQUEST.validator()
         val status: ValidationResult = validator.validate(attributes)
         assertTrue(status.isFailure())
@@ -232,10 +226,13 @@ internal class UAttributesValidatorTest {
     @DisplayName("Validate a UAttributes for payload that is meant to be an RPC request with invalid request id")
     fun test_validate_uAttributes_for_rpc_request_message_payload_invalid_request_id() {
         val uuidJava: java.util.UUID = java.util.UUID.randomUUID()
-        val attributes: UAttributes = UAttributesBuilder.request(UPriority.UPRIORITY_CS4, buildSink(), 1000).withReqId(
-            UUID.newBuilder().setMsb(uuidJava.mostSignificantBits).setLsb(uuidJava.leastSignificantBits)
-                .build()
-        ).build()
+        val attributes: UAttributes =
+            UAttributesBuilder.request(UPriority.UPRIORITY_CS4, buildSink(), 1000).withReqId(uUID {
+                msb = uuidJava.mostSignificantBits
+                lsb = uuidJava.leastSignificantBits
+            }
+
+            ).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.REQUEST.validator()
         val status: ValidationResult = validator.validate(attributes)
         assertTrue(status.isFailure())
@@ -247,8 +244,7 @@ internal class UAttributesValidatorTest {
     @DisplayName("Validate a UAttributes for payload that is meant to be an RPC response")
     fun test_validate_uAttributes_for_rpc_response_message_payload() {
         val attributes: UAttributes = UAttributesBuilder.response(
-            UPriority.UPRIORITY_CS4, buildSink(),
-            UuidFactory.Factories.UPROTOCOL.factory().create()
+            UPriority.UPRIORITY_CS4, buildSink(), UuidFactory.Factories.UPROTOCOL.factory().create()
         ).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.RESPONSE.validator()
         val status: ValidationResult = validator.validate(attributes)
@@ -260,8 +256,7 @@ internal class UAttributesValidatorTest {
     @DisplayName("Validate a UAttributes for payload that is meant to be an RPC response with all values")
     fun test_validate_uAttributes_for_rpc_response_message_payload_all_values() {
         val attributes: UAttributes = UAttributesBuilder.response(
-            UPriority.UPRIORITY_CS4, buildSink(),
-            UuidFactory.Factories.UPROTOCOL.factory().create()
+            UPriority.UPRIORITY_CS4, buildSink(), UuidFactory.Factories.UPROTOCOL.factory().create()
         ).withPermissionLevel(2).withCommStatus(3).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.RESPONSE.validator()
         val status: ValidationResult = validator.validate(attributes)
@@ -283,8 +278,7 @@ internal class UAttributesValidatorTest {
     @DisplayName("Validate a UAttributes for payload that is meant to be an RPC response with invalid time to live")
     fun test_validate_uAttributes_for_rpc_response_message_payload_invalid_ttl() {
         val attributes: UAttributes = UAttributesBuilder.response(
-            UPriority.UPRIORITY_CS4, buildSink(),
-            UuidFactory.Factories.UPROTOCOL.factory().create()
+            UPriority.UPRIORITY_CS4, buildSink(), UuidFactory.Factories.UPROTOCOL.factory().create()
         ).withTtl(-1).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.RESPONSE.validator()
         val status: ValidationResult = validator.validate(attributes)
@@ -294,8 +288,7 @@ internal class UAttributesValidatorTest {
 
     @Test
     @DisplayName(
-        "Validate a UAttributes for payload that is meant to be an RPC response with missing sink and " +
-                "missing request id"
+        "Validate a UAttributes for payload that is meant to be an RPC response with missing sink and " + "missing request id"
     )
     fun test_validate_uAttributes_for_rpc_response_message_payload_missing_sink_and_missing_requestId() {
         val attributes: UAttributes =
@@ -311,8 +304,7 @@ internal class UAttributesValidatorTest {
     @DisplayName("Validate a UAttributes for payload that is meant to be an RPC response with invalid permission level")
     fun test_validate_uAttributes_for_rpc_response_message_payload_invalid_permission_level() {
         val attributes: UAttributes = UAttributesBuilder.response(
-            UPriority.UPRIORITY_CS4, buildSink(),
-            UuidFactory.Factories.UPROTOCOL.factory().create()
+            UPriority.UPRIORITY_CS4, buildSink(), UuidFactory.Factories.UPROTOCOL.factory().create()
         ).withPermissionLevel(-42).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.RESPONSE.validator()
         val status: ValidationResult = validator.validate(attributes)
@@ -324,8 +316,7 @@ internal class UAttributesValidatorTest {
     @DisplayName("Validate a UAttributes for payload that is meant to be an RPC response with invalid communication " + "status")
     fun test_validate_uAttributes_for_rpc_response_message_payload_invalid_communication_status() {
         val attributes: UAttributes = UAttributesBuilder.response(
-            UPriority.UPRIORITY_CS4, buildSink(),
-            UuidFactory.Factories.UPROTOCOL.factory().create()
+            UPriority.UPRIORITY_CS4, buildSink(), UuidFactory.Factories.UPROTOCOL.factory().create()
         ).withCommStatus(-42).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.RESPONSE.validator()
         val status: ValidationResult = validator.validate(attributes)
@@ -348,8 +339,10 @@ internal class UAttributesValidatorTest {
     @DisplayName("Validate a UAttributes for payload that is meant to be an RPC response with invalid request id")
     fun test_validate_uAttributes_for_rpc_response_message_payload_invalid_request_id() {
         val uuidJava: java.util.UUID = java.util.UUID.randomUUID()
-        val reqid: UUID = UUID.newBuilder().setMsb(uuidJava.mostSignificantBits)
-            .setLsb(uuidJava.leastSignificantBits).build()
+        val reqid: UUID = uUID {
+            msb = uuidJava.mostSignificantBits
+            lsb = uuidJava.leastSignificantBits
+        }
         val attributes: UAttributes = UAttributesBuilder.response(UPriority.UPRIORITY_CS4, buildSink(), reqid).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.RESPONSE.validator()
         val status: ValidationResult = validator.validate(attributes)
@@ -447,10 +440,10 @@ internal class UAttributesValidatorTest {
     @DisplayName("test validating invalid ReqId attribute")
     fun test_validating_invalid_ReqId_attribute() {
         val uuidJava: java.util.UUID = java.util.UUID.randomUUID()
-        val attributes: UAttributes = UAttributesBuilder.publish(UPriority.UPRIORITY_CS0).withReqId(
-            UUID.newBuilder().setMsb(uuidJava.mostSignificantBits).setLsb(uuidJava.leastSignificantBits)
-                .build()
-        ).build()
+        val attributes: UAttributes = UAttributesBuilder.publish(UPriority.UPRIORITY_CS0).withReqId(uUID {
+            msb = uuidJava.mostSignificantBits
+            lsb = uuidJava.leastSignificantBits
+        }).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.PUBLISH.validator()
         val status: ValidationResult = validator.validateReqId(attributes)
         assertTrue(status.isFailure())
@@ -511,8 +504,7 @@ internal class UAttributesValidatorTest {
     @DisplayName("test validating valid commstatus attribute")
     fun test_validating_valid_commstatus_attribute() {
         val attributes: UAttributes =
-            UAttributesBuilder.publish(UPriority.UPRIORITY_CS0).withCommStatus(UCode.ABORTED_VALUE)
-                .build()
+            UAttributesBuilder.publish(UPriority.UPRIORITY_CS0).withCommStatus(UCode.ABORTED_VALUE).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.PUBLISH.validator()
         val status: ValidationResult = validator.validateCommStatus(attributes)
         assertEquals(ValidationResult.success(), status)
@@ -544,8 +536,7 @@ internal class UAttributesValidatorTest {
     @DisplayName("test validating request validator using bad ttl")
     fun test_validating_request_validator_with_wrong_bad_ttl() {
         val attributes: UAttributes = UAttributesBuilder.request(
-            UPriority.UPRIORITY_CS6,
-            LongUriSerializer.instance().deserialize("/hartley/1/rpc.response"), -1
+            UPriority.UPRIORITY_CS6, LongUriSerializer.instance().deserialize("/hartley/1/rpc.response"), -1
         ).build()
         val validator: UAttributesValidator = UAttributesValidator.Validators.REQUEST.validator()
         assertEquals("UAttributesValidator.Request", validator.toString())
@@ -589,8 +580,7 @@ internal class UAttributesValidatorTest {
         val status: ValidationResult = validator.validate(attributes)
         assertTrue(status.isFailure())
         assertEquals(
-            "Wrong Attribute Type [UMESSAGE_TYPE_PUBLISH],Missing Sink,Missing correlationId",
-            status.getMessage()
+            "Wrong Attribute Type [UMESSAGE_TYPE_PUBLISH],Missing Sink,Missing correlationId", status.getMessage()
         )
     }
 
@@ -605,8 +595,14 @@ internal class UAttributesValidatorTest {
     }
 
     private fun buildSink(): UUri {
-        return UUri.newBuilder().setAuthority(UAuthority.newBuilder().setName("vcu.someVin.veh.ultifi.gm.com"))
-            .setEntity(UEntity.newBuilder().setName("petapp.ultifi.gm.com").setVersionMajor(1))
-            .setResource(UResourceBuilder.forRpcResponse()).build()
+        return uUri {
+            authority = uAuthority { name = "vcu.someVin.veh.ultifi.gm.com" }
+            entity = uEntity {
+                name = "petapp.ultifi.gm.com"
+                versionMajor = 1
+            }
+            resource = UResourceBuilder.forRpcResponse()
+        }
+
     }
 }

--- a/src/test/kotlin/org/eclipse/uprotocol/uri/serializer/LongUriSerializerTest.kt
+++ b/src/test/kotlin/org/eclipse/uprotocol/uri/serializer/LongUriSerializerTest.kt
@@ -20,23 +20,26 @@
  */
 package org.eclipse.uprotocol.uri.serializer
 
+import com.google.protobuf.ByteString
 import org.eclipse.uprotocol.uri.builder.UResourceBuilder
 import org.eclipse.uprotocol.uri.validator.UriValidator
-import org.eclipse.uprotocol.v1.UAuthority
-import org.eclipse.uprotocol.v1.UEntity
-import org.eclipse.uprotocol.v1.UResource
-import org.eclipse.uprotocol.v1.UUri
+import org.eclipse.uprotocol.v1.*
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import java.util.Optional
-import org.junit.jupiter.api.Assertions.*
+import java.net.InetAddress
+import java.util.*
+
 
 class LongUriSerializerTest {
     @Test
     @DisplayName("Test using the serializers")
     fun test_using_the_serializers() {
-        val uri: UUri = UUri.newBuilder().setEntity(UEntity.newBuilder().setName("hartley"))
-            .setResource(UResourceBuilder.forRpcRequest("raise")).build()
+        val uri: UUri = uUri {
+            entity = uEntity { name = "hartley" }
+            resource = UResourceBuilder.forRpcRequest("raise")
+        }
+
         val strUri: String = LongUriSerializer.instance().serialize(uri)
         assertEquals("/hartley//rpc.raise", strUri)
         val uri2: UUri = LongUriSerializer.instance().deserialize(strUri)
@@ -71,7 +74,7 @@ class LongUriSerializerTest {
         assertTrue(UriValidator.isEmpty(uuri))
         assertFalse(uuri.hasResource())
         assertFalse(uuri.hasEntity())
-        val uri2: String = LongUriSerializer.instance().serialize(UUri.newBuilder().build())
+        val uri2: String = LongUriSerializer.instance().serialize(uUri { })
         assertTrue(uri2.isEmpty())
     }
 
@@ -588,7 +591,7 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an empty  URI Object")
     fun test_build_protocol_uri_from__uri_when__uri_isEmpty() {
-        val uuri: UUri = UUri.newBuilder().build()
+        val uuri: UUri = uUri { }
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("", uProtocolUri)
     }
@@ -596,9 +599,12 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI object with an empty USE")
     fun test_build_protocol_uri_from__uri_when__uri_has_empty_use() {
-        val use: UEntity = UEntity.newBuilder().build()
-        val uuri: UUri = UUri.newBuilder().setAuthority(UAuthority.newBuilder().build()).setEntity(use)
-            .setResource(UResource.newBuilder().setName("door").build()).build()
+        val use: UEntity = uEntity { }
+        val uuri: UUri = uUri {
+            authority = uAuthority { }
+            entity = use
+            resource = uResource { name = "door" }
+        }
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("/////door", uProtocolUri)
     }
@@ -606,7 +612,8 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a local authority with service no version")
     fun test_build_protocol_uri_from__uri_when__uri_has_local_authority_service_no_version() {
-        val uuri: UUri = UUri.newBuilder().setEntity(UEntity.newBuilder().setName("body.access").build()).build()
+        val uuri: UUri = uUri { entity = uEntity { name = "body.access" } }
+
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("/body.access", uProtocolUri)
     }
@@ -614,8 +621,14 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a local authority with service and version")
     fun test_build_protocol_uri_from__uri_when__uri_has_local_authority_service_and_version() {
-        val use: UEntity = UEntity.newBuilder().setName("body.access").setVersionMajor(1).build()
-        val uuri: UUri = UUri.newBuilder().setEntity(use).setResource(UResource.newBuilder().build()).build()
+        val use: UEntity = uEntity {
+            name = "body.access"
+            versionMajor = 1
+        }
+        val uuri: UUri = uUri {
+            entity = use
+            resource = uResource { }
+        }
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("/body.access/1", uProtocolUri)
     }
@@ -623,9 +636,14 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a local authority with service no version with resource")
     fun test_build_protocol_uri_from__uri_when__uri_has_local_authority_service_no_version_with_resource() {
-        val use: UEntity = UEntity.newBuilder().setName("body.access").build()
-        val uuri: UUri =
-            UUri.newBuilder().setEntity(use).setResource(UResource.newBuilder().setName("door").build()).build()
+        val use: UEntity = uEntity {
+            name = "body.access"
+        }
+        val uuri: UUri = uUri {
+            entity = use
+            resource = uResource { name = "door" }
+        }
+
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("/body.access//door", uProtocolUri)
     }
@@ -633,9 +651,15 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a local authority with service and version with resource")
     fun test_build_protocol_uri_from__uri_when__uri_has_local_authority_service_and_version_with_resource() {
-        val use: UEntity = UEntity.newBuilder().setName("body.access").setVersionMajor(1).build()
-        val uuri: UUri =
-            UUri.newBuilder().setEntity(use).setResource(UResource.newBuilder().setName("door").build()).build()
+        val use: UEntity = uEntity {
+            name = "body.access"
+            versionMajor = 1
+        }
+        val uuri: UUri = uUri {
+            entity = use
+            resource = uResource { name = "door" }
+        }
+
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("/body.access/1/door", uProtocolUri)
     }
@@ -643,9 +667,17 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a local authority with service no version with resource with instance no message")
     fun test_build_protocol_uri_from__uri_when__uri_has_local_authority_service_no_version_with_resource_with_instance_no_getMessage() {
-        val use: UEntity = UEntity.newBuilder().setName("body.access").build()
-        val uuri: UUri = UUri.newBuilder().setEntity(use)
-            .setResource(UResource.newBuilder().setName("door").setInstance("front_left").build()).build()
+        val use: UEntity = uEntity {
+            name = "body.access"
+        }
+        val uuri: UUri = uUri {
+            entity = use
+            resource = uResource {
+                name = "door"
+                instance = "front_left"
+            }
+        }
+
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("/body.access//door.front_left", uProtocolUri)
     }
@@ -653,9 +685,19 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a local authority with service and version with resource with instance no message")
     fun test_build_protocol_uri_from__uri_when__uri_has_local_authority_service_and_version_with_resource_with_instance_no_getMessage() {
-        val use: UEntity = UEntity.newBuilder().setName("body.access").setVersionMajor(1).build()
-        val uuri: UUri = UUri.newBuilder().setEntity(use)
-            .setResource(UResource.newBuilder().setName("door").setInstance("front_left").build()).build()
+        val use: UEntity = uEntity {
+            name = "body.access"
+            versionMajor = 1
+        }
+        val uuri: UUri = uUri {
+            entity = use
+            resource = uResource {
+                name = "door"
+                instance = "front_left"
+            }
+        }
+
+
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("/body.access/1/door.front_left", uProtocolUri)
     }
@@ -663,10 +705,19 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a local authority with service no version with resource with instance and message")
     fun test_build_protocol_uri_from__uri_when__uri_has_local_authority_service_no_version_with_resource_with_instance_with_getMessage() {
-        val use: UEntity = UEntity.newBuilder().setName("body.access").build()
-        val uuri: UUri = UUri.newBuilder().setEntity(use)
-            .setResource(UResource.newBuilder().setName("door").setInstance("front_left").setMessage("Door").build())
-            .build()
+        val use: UEntity = uEntity {
+            name = "body.access"
+        }
+        val uuri: UUri = uUri {
+            entity = use
+            resource = uResource {
+                name = "door"
+                instance = "front_left"
+                message = "Door"
+            }
+        }
+
+
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("/body.access//door.front_left#Door", uProtocolUri)
     }
@@ -674,10 +725,18 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a local authority with service and version with resource with instance and message")
     fun test_build_protocol_uri_from__uri_when__uri_has_local_authority_service_and_version_with_resource_with_instance_with_getMessage() {
-        val use: UEntity = UEntity.newBuilder().setName("body.access").setVersionMajor(1).build()
-        val uuri: UUri = UUri.newBuilder().setEntity(use)
-            .setResource(UResource.newBuilder().setName("door").setInstance("front_left").setMessage("Door").build())
-            .build()
+        val use: UEntity = uEntity {
+            name = "body.access"
+            versionMajor = 1
+        }
+        val uuri: UUri = uUri {
+            entity = use
+            resource = uResource {
+                name = "door"
+                instance = "front_left"
+                message = "Door"
+            }
+        }
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("/body.access/1/door.front_left#Door", uProtocolUri)
     }
@@ -685,10 +744,12 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a microRemote authority with service no version")
     fun test_build_protocol_uri_from__uri_when__uri_has_remote_authority_service_no_version() {
-        val use: UEntity = UEntity.newBuilder().setName("body.access").build()
-        val uuri: UUri =
-            UUri.newBuilder().setAuthority(UAuthority.newBuilder().setName("vcu.my_car_vin").build()).setEntity(use)
-                .build()
+        val use: UEntity = uEntity { name = "body.access" }
+        val uuri: UUri = uUri {
+            authority = uAuthority { name = "vcu.my_car_vin" }
+            entity = use
+        }
+
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("//vcu.my_car_vin/body.access", uProtocolUri)
     }
@@ -696,10 +757,18 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a microRemote authority with service and version")
     fun test_build_protocol_uri_from__uri_when__uri_has_remote_authority_service_and_version() {
-        val use: UEntity = UEntity.newBuilder().setName("body.access").setVersionMajor(1).build()
-        val uuri: UUri =
-            UUri.newBuilder().setAuthority(UAuthority.newBuilder().setName("vcu.my_car_vin").build()).setEntity(use)
-                .build()
+        val use: UEntity = uEntity {
+            name = "body.access"
+            versionMajor = 1
+        }
+        val uuri: UUri = uUri {
+            entity = use
+            authority = uAuthority {
+                name = "vcu.my_car_vin"
+
+            }
+        }
+
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("//vcu.my_car_vin/body.access/1", uProtocolUri)
     }
@@ -707,10 +776,15 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a microRemote cloud authority with service and version")
     fun test_build_protocol_uri_from__uri_when__uri_has_remote_cloud_authority_service_and_version() {
-        val use: UEntity = UEntity.newBuilder().setName("body.access").setVersionMajor(1).build()
-        val uuri: UUri =
-            UUri.newBuilder().setAuthority(UAuthority.newBuilder().setName("cloud.uprotocol.example.com").build())
-                .setEntity(use).build()
+        val use: UEntity = uEntity {
+            name = "body.access"
+            versionMajor = 1
+        }
+        val uuri: UUri = uUri {
+            authority = uAuthority { name = "cloud.uprotocol.example.com" }
+            entity = use
+        }
+
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("//cloud.uprotocol.example.com/body.access/1", uProtocolUri)
     }
@@ -718,10 +792,16 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a microRemote authority with service and version with resource")
     fun test_build_protocol_uri_from__uri_when__uri_has_remote_authority_service_and_version_with_resource() {
-        val use: UEntity = UEntity.newBuilder().setName("body.access").setVersionMajor(1).build()
-        val uuri: UUri =
-            UUri.newBuilder().setAuthority(UAuthority.newBuilder().setName("vcu.my_car_vin").build()).setEntity(use)
-                .setResource(UResource.newBuilder().setName("door").build()).build()
+        val use: UEntity = uEntity {
+            name = "body.access"
+            versionMajor = 1
+        }
+        val uuri: UUri = uUri {
+            authority = uAuthority { name = "vcu.my_car_vin" }
+            entity = use
+            resource = uResource { name = "door" }
+        }
+
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("//vcu.my_car_vin/body.access/1/door", uProtocolUri)
     }
@@ -729,10 +809,16 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a microRemote authority with service no version with resource")
     fun test_build_protocol_uri_from__uri_when__uri_has_remote_authority_service_no_version_with_resource() {
-        val use: UEntity = UEntity.newBuilder().setName("body.access").build()
-        val uuri: UUri =
-            UUri.newBuilder().setAuthority(UAuthority.newBuilder().setName("vcu.my_car_vin").build()).setEntity(use)
-                .setResource(UResource.newBuilder().setName("door").build()).build()
+        val use: UEntity = uEntity {
+            name = "body.access"
+
+        }
+        val uuri: UUri = uUri {
+            authority = uAuthority { name = "vcu.my_car_vin" }
+            entity = use
+            resource = uResource { name = "door" }
+        }
+
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("//vcu.my_car_vin/body.access//door", uProtocolUri)
     }
@@ -740,10 +826,19 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a microRemote authority with service and version with resource with instance no message")
     fun test_build_protocol_uri_from__uri_when__uri_has_remote_authority_service_and_version_with_resource_with_instance_no_getMessage() {
-        val use: UEntity = UEntity.newBuilder().setName("body.access").setVersionMajor(1).build()
-        val uuri: UUri =
-            UUri.newBuilder().setAuthority(UAuthority.newBuilder().setName("vcu.my_car_vin").build()).setEntity(use)
-                .setResource(UResource.newBuilder().setName("door").setInstance("front_left").build()).build()
+        val use: UEntity = uEntity {
+            name = "body.access"
+            versionMajor = 1
+        }
+        val uuri: UUri = uUri {
+            authority = uAuthority { name = "vcu.my_car_vin" }
+            entity = use
+            resource = uResource {
+                name = "door"
+                instance = "front_left"
+            }
+        }
+
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("//vcu.my_car_vin/body.access/1/door.front_left", uProtocolUri)
     }
@@ -751,12 +846,19 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a microRemote cloud authority with service and version with resource with instance no message")
     fun test_build_protocol_uri_from__uri_when__uri_has_remote_cloud_authority_service_and_version_with_resource_with_instance_no_getMessage() {
-        val use: UEntity = UEntity.newBuilder().setName("body.access").setVersionMajor(1).build()
-        val uuri: UUri =
-            UUri.newBuilder().setAuthority(UAuthority.newBuilder().setName("cloud.uprotocol.example.com").build())
-                .setEntity(use).setResource(
-                UResource.newBuilder().setName("door").setInstance("front_left").build()
-            ).build()
+        val use: UEntity = uEntity {
+            name = "body.access"
+            versionMajor = 1
+        }
+        val uuri: UUri = uUri {
+            authority = uAuthority { name = "cloud.uprotocol.example.com" }
+            entity = use
+            resource = uResource {
+                name = "door"
+                instance = "front_left"
+            }
+        }
+
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("//cloud.uprotocol.example.com/body.access/1/door.front_left", uProtocolUri)
     }
@@ -764,10 +866,18 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a microRemote authority with service no version with resource with instance no message")
     fun test_build_protocol_uri_from__uri_when__uri_has_remote_authority_service_no_version_with_resource_with_instance_no_getMessage() {
-        val use: UEntity = UEntity.newBuilder().setName("body.access").build()
-        val uuri: UUri =
-            UUri.newBuilder().setAuthority(UAuthority.newBuilder().setName("vcu.my_car_vin").build()).setEntity(use)
-                .setResource(UResource.newBuilder().setName("door").setInstance("front_left").build()).build()
+        val use: UEntity = uEntity {
+            name = "body.access"
+        }
+        val uuri: UUri = uUri {
+            authority = uAuthority { name = "vcu.my_car_vin" }
+            entity = use
+            resource = uResource {
+                name = "door"
+                instance = "front_left"
+            }
+        }
+
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("//vcu.my_car_vin/body.access//door.front_left", uProtocolUri)
     }
@@ -775,12 +885,21 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a microRemote authority with service and version with resource with instance and message")
     fun test_build_protocol_uri_from__uri_when__uri_has_remote_authority_service_and_version_with_resource_with_instance_and_getMessage() {
-        val use: UEntity = UEntity.newBuilder().setName("body.access").setVersionMajor(1).build()
-        val uuri: UUri =
-            UUri.newBuilder().setAuthority(UAuthority.newBuilder().setName("vcu.my_car_vin").build()).setEntity(use)
-                .setResource(
-                    UResource.newBuilder().setName("door").setInstance("front_left").setMessage("Door").build()
-                ).build()
+        val use: UEntity = uEntity {
+            name = "body.access"
+            versionMajor = 1
+        }
+        val uuri: UUri = uUri {
+            authority = uAuthority { name = "vcu.my_car_vin" }
+            entity = use
+            resource = uResource {
+                name = "door"
+                instance = "front_left"
+                message = "Door"
+            }
+        }
+
+
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("//vcu.my_car_vin/body.access/1/door.front_left#Door", uProtocolUri)
     }
@@ -788,12 +907,19 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI from an  URI Object with a microRemote authority with service no version with resource with instance and message")
     fun test_build_protocol_uri_from__uri_when__uri_has_remote_authority_service_no_version_with_resource_with_instance_and_getMessage() {
-        val use: UEntity = UEntity.newBuilder().setName("body.access").build()
-        val uuri: UUri =
-            UUri.newBuilder().setAuthority(UAuthority.newBuilder().setName("vcu.my_car_vin").build()).setEntity(use)
-                .setResource(
-                    UResource.newBuilder().setName("door").setInstance("front_left").setMessage("Door").build()
-                ).build()
+        val use: UEntity = uEntity {
+            name = "body.access"
+        }
+        val uuri: UUri = uUri {
+            authority = uAuthority { name = "vcu.my_car_vin" }
+            entity = use
+            resource = uResource {
+                name = "door"
+                instance = "front_left"
+                message = "Door"
+            }
+        }
+
         val uProtocolUri: String = LongUriSerializer.instance().serialize(uuri)
         assertEquals("//vcu.my_car_vin/body.access//door.front_left#Door", uProtocolUri)
     }
@@ -801,44 +927,72 @@ class LongUriSerializerTest {
     @Test
     @DisplayName("Test Create a uProtocol URI for the source part of an RPC request, where the source is local")
     fun test_build_protocol_uri_for_source_part_of_rpc_request_where_source_is_local() {
-        val use: UEntity = UEntity.newBuilder().setName("petapp").setVersionMajor(1).build()
-        val resource: UResource = UResource.newBuilder().setName("rpc").setInstance("response").build()
-        val uProtocolUri: String =
-            LongUriSerializer.instance().serialize(UUri.newBuilder().setEntity(use).setResource(resource).build())
+        val use: UEntity = uEntity {
+            name = "petapp"
+            versionMajor = 1
+        }
+        val uResource: UResource = uResource {
+            name = "rpc"
+            instance = "response"
+        }
+        val uProtocolUri: String = LongUriSerializer.instance().serialize(uUri {
+            entity = use
+            resource = uResource
+        })
         assertEquals("/petapp/1/rpc.response", uProtocolUri)
     }
 
     @Test
     @DisplayName("Test Create a uProtocol URI for the source part of an RPC request, where the source is microRemote")
     fun test_build_protocol_uri_for_source_part_of_rpc_request_where_source_is_remote() {
-        val uAuthority: UAuthority = UAuthority.newBuilder().setName("cloud.uprotocol.example.com").build()
-        val use: UEntity = UEntity.newBuilder().setName("petapp").build()
-        val resource: UResource = UResource.newBuilder().setName("rpc").setInstance("response").build()
-        val uProtocolUri: String = LongUriSerializer.instance()
-            .serialize(UUri.newBuilder().setAuthority(uAuthority).setEntity(use).setResource(resource).build())
+        val uAuthority: UAuthority = uAuthority { name = "cloud.uprotocol.example.com" }
+        val use: UEntity = uEntity {
+            name = "petapp"
+        }
+        val uResource: UResource = uResource {
+            name = "rpc"
+            instance = "response"
+        }
+        val uProtocolUri: String = LongUriSerializer.instance().serialize(uUri {
+            authority = uAuthority
+            entity = use
+            resource = uResource
+        })
         assertEquals("//cloud.uprotocol.example.com/petapp//rpc.response", uProtocolUri)
     }
 
     @Test
     @DisplayName("Test Create a uProtocol URI from the parts of  URI Object with a microRemote authority with service and version with resource")
     fun test_build_protocol_uri_from__uri_parts_when__uri_has_remote_authority_service_and_version_with_resource() {
-        val uAuthority: UAuthority = UAuthority.newBuilder().setName("vcu.my_car_vin").build()
-        val use: UEntity = UEntity.newBuilder().setName("body.access").setVersionMajor(1).build()
-        val uResource: UResource = UResource.newBuilder().setName("door").build()
-        val uProtocolUri: String = LongUriSerializer.instance()
-            .serialize(UUri.newBuilder().setAuthority(uAuthority).setEntity(use).setResource(uResource).build())
+        val uAuthority: UAuthority = uAuthority { name = "vcu.my_car_vin" }
+        val use: UEntity = uEntity {
+            name = "body.access"
+            versionMajor = 1
+        }
+        val uResource: UResource = uResource { name = "door" }
+        val uProtocolUri: String = LongUriSerializer.instance().serialize(uUri {
+            authority = uAuthority
+            entity = use
+            resource = uResource
+        })
         assertEquals("//vcu.my_car_vin/body.access/1/door", uProtocolUri)
     }
 
     @Test
     @DisplayName("Test Create a custom URI using no scheme")
     fun test_custom_scheme_no_scheme() {
-        val uAuthority: UAuthority = UAuthority.newBuilder().setName("vcu.my_car_vin").build()
-        val use: UEntity = UEntity.newBuilder().setName("body.access").setVersionMajor(1).build()
-        val uResource: UResource = UResource.newBuilder().setName("door").build()
-        val ucustomUri: String = LongUriSerializer.instance().serialize(
-            UUri.newBuilder().setAuthority(uAuthority)
-                .setEntity(use).setResource(uResource).build()
+        val uAuthority: UAuthority = uAuthority { name = "vcu.my_car_vin" }
+        val use: UEntity = uEntity {
+            name = "body.access"
+            versionMajor = 1
+        }
+        val uResource: UResource = uResource { name = "door" }
+        val ucustomUri: String = LongUriSerializer.instance().serialize(uUri {
+            authority = uAuthority
+            entity = use
+            resource = uResource
+        }
+
         )
         assertEquals("//vcu.my_car_vin/body.access/1/door", ucustomUri)
     }

--- a/src/test/kotlin/org/eclipse/uprotocol/uri/serializer/MicroUriSerializerTest.kt
+++ b/src/test/kotlin/org/eclipse/uprotocol/uri/serializer/MicroUriSerializerTest.kt
@@ -23,16 +23,13 @@ package org.eclipse.uprotocol.uri.serializer
 import com.google.protobuf.ByteString
 import org.eclipse.uprotocol.uri.builder.UResourceBuilder
 import org.eclipse.uprotocol.uri.validator.UriValidator
-import org.eclipse.uprotocol.v1.UAuthority
-import org.eclipse.uprotocol.v1.UEntity
-import org.eclipse.uprotocol.v1.UResource
-import org.eclipse.uprotocol.v1.UUri
+import org.eclipse.uprotocol.v1.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.net.InetAddress
 import java.net.UnknownHostException
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 
 class MicroUriSerializerTest {
     @Test
@@ -56,8 +53,14 @@ class MicroUriSerializerTest {
     @Test
     @DisplayName("Test happy path Byte serialization of local UUri")
     fun test_serialize_uri() {
-        val uri: UUri = UUri.newBuilder().setEntity(UEntity.newBuilder().setId(29999).setVersionMajor(254).build())
-            .setResource(UResource.newBuilder().setId(19999).build()).build()
+        val uri: UUri = uUri {
+            entity = uEntity {
+                id = 29999
+                versionMajor = 254
+            }
+            resource = uResource { id = 19999 }
+        }
+
         val bytes: ByteArray = MicroUriSerializer.instance().serialize(uri)
         val uri2: UUri = MicroUriSerializer.instance().deserialize(bytes)
         assertEquals(uri, uri2)
@@ -66,9 +69,15 @@ class MicroUriSerializerTest {
     @Test
     @DisplayName("Test Serialize a remote UUri to micro without the address")
     fun test_serialize_remote_uri_without_address() {
-        val uri: UUri = UUri.newBuilder().setAuthority(UAuthority.newBuilder().setName("vcu.vin").build())
-            .setEntity(UEntity.newBuilder().setId(29999).setVersionMajor(254).build())
-            .setResource(UResource.newBuilder().setId(19999).build()).build()
+        val uri: UUri = uUri {
+            authority = uAuthority { name = "vcu.vin" }
+            entity = uEntity {
+                id = 29999
+                versionMajor = 254
+            }
+            resource = uResource { id = 19999 }
+        }
+
         val bytes: ByteArray = MicroUriSerializer.instance().serialize(uri)
         assertTrue(bytes.isEmpty())
     }
@@ -76,8 +85,12 @@ class MicroUriSerializerTest {
     @Test
     @DisplayName("Test serialize Uri missing uE ID")
     fun test_serialize_uri_missing_ids() {
-        val uri: UUri = UUri.newBuilder().setEntity(UEntity.newBuilder().setName("hartley").build())
-            .setResource(UResourceBuilder.forRpcResponse()).build()
+        val uri: UUri = uUri {
+            entity = uEntity { name = "hartley" }
+            resource = UResourceBuilder.forRpcResponse()
+        }
+
+
         val bytes: ByteArray = MicroUriSerializer.instance().serialize(uri)
         assertTrue(bytes.isEmpty())
     }
@@ -85,7 +98,8 @@ class MicroUriSerializerTest {
     @Test
     @DisplayName("Test serialize Uri missing resource")
     fun test_serialize_uri_missing_resource_id() {
-        val uri: UUri = UUri.newBuilder().setEntity(UEntity.newBuilder().setName("hartley").build()).build()
+        val uri: UUri = uUri { entity = uEntity { name = "hartley" } }
+
         val bytes: ByteArray = MicroUriSerializer.instance().serialize(uri)
         assertTrue(bytes.isEmpty())
     }
@@ -135,10 +149,16 @@ class MicroUriSerializerTest {
     @DisplayName("Test serialize with good IPv4 based authority")
     @Throws(UnknownHostException::class)
     fun test_serialize_good_ipv4_based_authority() {
-        val uri: UUri = UUri.newBuilder().setAuthority(
-            UAuthority.newBuilder().setIp(ByteString.copyFrom(InetAddress.getByName("10.0.3.3").address)).build()
-        ).setEntity(UEntity.newBuilder().setId(29999).setVersionMajor(254).build())
-            .setResource(UResourceBuilder.forRpcRequest(99)).build()
+        val uri: UUri = uUri {
+            authority = uAuthority { ip = ByteString.copyFrom(InetAddress.getByName("10.0.3.3").address) }
+            entity = uEntity {
+                id = 29999
+                versionMajor = 254
+            }
+            resource = UResourceBuilder.forRpcRequest(99)
+        }
+
+
         val bytes: ByteArray = MicroUriSerializer.instance().serialize(uri)
         val uri2: UUri = MicroUriSerializer.instance().deserialize(bytes)
         assertTrue(bytes.isNotEmpty())
@@ -152,14 +172,20 @@ class MicroUriSerializerTest {
     @DisplayName("Test serialize with good IPv6 based authority")
     @Throws(UnknownHostException::class)
     fun test_serialize_good_ipv6_based_authority() {
-        val uri: UUri = UUri.newBuilder().setAuthority(
-            UAuthority.newBuilder().setIp(
-                ByteString.copyFrom(
+        val uri: UUri = uUri {
+            authority = uAuthority {
+                ip = ByteString.copyFrom(
                     InetAddress.getByName("2001:0db8:85a3:0000:0000:8a2e:0370:7334").address
                 )
-            ).build()
-        ).setEntity(UEntity.newBuilder().setId(29999).setVersionMajor(254).build())
-            .setResource(UResource.newBuilder().setId(19999).build()).build()
+            }
+            entity = uEntity {
+                id = 29999
+                versionMajor = 254
+            }
+
+            resource = uResource { id = 19999 }
+        }
+
         val bytes: ByteArray = MicroUriSerializer.instance().serialize(uri)
         val uri2: UUri = MicroUriSerializer.instance().deserialize(bytes)
         assertTrue(UriValidator.isMicroForm(uri))
@@ -176,10 +202,15 @@ class MicroUriSerializerTest {
         for (i in 0 until size) {
             byteArray[i] = i.toByte()
         }
-        val uri: UUri =
-            UUri.newBuilder().setAuthority(UAuthority.newBuilder().setId(ByteString.copyFrom(byteArray)).build())
-                .setEntity(UEntity.newBuilder().setId(29999).setVersionMajor(254).build())
-                .setResource(UResource.newBuilder().setId(19999).build()).build()
+        val uri: UUri = uUri {
+            authority = uAuthority { id = ByteString.copyFrom(byteArray) }
+            entity = uEntity {
+                id = 29999
+                versionMajor = 254
+            }
+            resource = uResource { id = 19999 }
+        }
+
         val bytes: ByteArray = MicroUriSerializer.instance().serialize(uri)
         val uri2: UUri = MicroUriSerializer.instance().deserialize(bytes)
         assertTrue(UriValidator.isMicroForm(uri))
@@ -192,10 +223,17 @@ class MicroUriSerializerTest {
     @Throws(UnknownHostException::class)
     fun test_serialize_bad_length_ip_based_authority() {
         val byteArray = byteArrayOf(127, 1, 23, 123, 12, 6)
-        val uri: UUri =
-            UUri.newBuilder().setAuthority(UAuthority.newBuilder().setIp(ByteString.copyFrom(byteArray)).build())
-                .setEntity(UEntity.newBuilder().setId(29999).setVersionMajor(254).build())
-                .setResource(UResource.newBuilder().setId(19999).build()).build()
+        val uri: UUri = uUri {
+            authority = uAuthority {
+                ip = ByteString.copyFrom(byteArray)
+            }
+            entity = uEntity {
+                id = 29999
+                versionMajor = 254
+            }
+            resource = uResource { id = 19999 }
+        }
+
         val bytes: ByteArray = MicroUriSerializer.instance().serialize(uri)
         assertTrue(bytes.isEmpty())
     }
@@ -209,10 +247,15 @@ class MicroUriSerializerTest {
         for (i in 0 until size) {
             byteArray[i] = i.toByte()
         }
-        val uri: UUri =
-            UUri.newBuilder().setAuthority(UAuthority.newBuilder().setId(ByteString.copyFrom(byteArray)).build())
-                .setEntity(UEntity.newBuilder().setId(29999).setVersionMajor(254).build())
-                .setResource(UResource.newBuilder().setId(19999).build()).build()
+        val uri: UUri = uUri {
+            authority = uAuthority { id = ByteString.copyFrom(byteArray) }
+            entity = uEntity {
+                id = 29999
+                versionMajor = 254
+            }
+            resource = uResource { id = 19999 }
+        }
+
         val bytes: ByteArray = MicroUriSerializer.instance().serialize(uri)
         assertEquals(bytes.size, 9 + size)
         val uri2: UUri = MicroUriSerializer.instance().deserialize(bytes)

--- a/src/test/kotlin/org/eclipse/uprotocol/uri/serializer/UriSerializerTest.kt
+++ b/src/test/kotlin/org/eclipse/uprotocol/uri/serializer/UriSerializerTest.kt
@@ -21,24 +21,34 @@
 package org.eclipse.uprotocol.uri.serializer
 
 import org.eclipse.uprotocol.uri.validator.UriValidator
-import org.eclipse.uprotocol.v1.UAuthority
-import org.eclipse.uprotocol.v1.UEntity
-import org.eclipse.uprotocol.v1.UResource
-import org.eclipse.uprotocol.v1.UUri
+import org.eclipse.uprotocol.v1.*
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import java.util.Optional
-import org.junit.jupiter.api.Assertions.*
+import java.util.*
 
 class UriSerializerTest {
     @Test
     @DisplayName("Test build resolve with valid long and micro uri")
     fun test_build_resolved_valid_long_micro_uri() {
-        val longUUri: UUri = UUri.newBuilder().setAuthority(UAuthority.newBuilder().setName("testauth").build())
-            .setEntity(UEntity.newBuilder().setName("neelam"))
-            .setResource(UResource.newBuilder().setName("rpc").setInstance("response").build()).build()
-        val microUUri: UUri = UUri.newBuilder().setEntity(UEntity.newBuilder().setId(29999).setVersionMajor(254))
-            .setResource(UResource.newBuilder().setId(39999)).build()
+        val longUUri: UUri = uUri {
+            authority = uAuthority { name = "testauth" }
+            entity = uEntity { name = "neelam" }
+            resource = uResource {
+                name = "rpc"
+                instance = "response"
+            }
+        }
+
+        val microUUri: UUri = uUri {
+            entity = uEntity {
+                id = 29999
+                versionMajor = 254
+            }
+            resource = uResource { id = 39999 }
+        }
+
+
         val microuri: ByteArray = MicroUriSerializer.instance().serialize(microUUri)
         val longuri: String = LongUriSerializer.instance().serialize(longUUri)
         val resolvedUUri: Optional<UUri> = LongUriSerializer.instance().buildResolved(longuri, microuri)

--- a/src/test/kotlin/org/eclipse/uprotocol/uri/validator/UriValidatorTest.kt
+++ b/src/test/kotlin/org/eclipse/uprotocol/uri/validator/UriValidatorTest.kt
@@ -21,21 +21,18 @@
 package org.eclipse.uprotocol.uri.validator
 
 import org.eclipse.uprotocol.uri.serializer.LongUriSerializer
-import org.eclipse.uprotocol.v1.UAuthority
-import org.eclipse.uprotocol.v1.UEntity
-import org.eclipse.uprotocol.v1.UResource
-import org.eclipse.uprotocol.v1.UUri
+import org.eclipse.uprotocol.v1.*
 import org.eclipse.uprotocol.validation.ValidationResult
 import org.json.JSONArray
 import org.json.JSONObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
 import java.io.IOException
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 
 internal class UriValidatorTest {
     @Test
@@ -403,9 +400,16 @@ internal class UriValidatorTest {
     @Test
     @DisplayName("Test validate rpc method uri is invalid when uri has authority but missing remote case")
     fun test_rpc_method_uri_invalid_when_uri_is_remote_missing_authority_remotecase() {
-        val uuri: UUri = UUri.newBuilder().setEntity(UEntity.newBuilder().setName("body.access").build())
-            .setResource(UResource.newBuilder().setName("rpc").setInstance("UpdateDoor").build())
-            .setAuthority(UAuthority.newBuilder().build()).build()
+        val uuri: UUri = uUri {
+            entity = uEntity { name = "body.access" }
+            resource = uResource {
+                name = "rpc"
+                instance = "UpdateDoor"
+            }
+            authority = uAuthority { }
+        }
+
+
         val status: ValidationResult = UriValidator.validateRpcMethod(uuri)
         assertTrue(status.isFailure())
         assertEquals("Uri is remote missing uAuthority.", status.getMessage())
@@ -509,8 +513,14 @@ internal class UriValidatorTest {
     @DisplayName("Test valid rpc response uri")
     @Throws(IOException::class)
     fun test_valid_rpc_response_uri() {
-        val uuri: UUri = UUri.newBuilder().setEntity(UEntity.newBuilder().setName("hartley").build())
-            .setResource(UResource.newBuilder().setName("rpc").setId(19999).build()).build()
+        val uuri: UUri = uUri {
+            entity = uEntity { name = "hartley" }
+            resource = uResource {
+                name = "rpc"
+                id = 19999
+            }
+        }
+
         val status: ValidationResult = UriValidator.validateRpcResponse(uuri)
         assertTrue(UriValidator.isRpcResponse(uuri))
         assertTrue(status.isSuccess())

--- a/src/test/kotlin/org/eclipse/uprotocol/uuid/factory/UUIDFactoryTest.kt
+++ b/src/test/kotlin/org/eclipse/uprotocol/uuid/factory/UUIDFactoryTest.kt
@@ -24,6 +24,7 @@ package org.eclipse.uprotocol.uuid.factory
 import org.eclipse.uprotocol.uuid.serializer.LongUuidSerializer
 import org.eclipse.uprotocol.uuid.serializer.MicroUuidSerializer
 import org.eclipse.uprotocol.v1.UUID
+import org.eclipse.uprotocol.v1.uUID
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -163,7 +164,10 @@ class UUIDFactoryTest {
     @DisplayName("Test UuidUtils for Random UUID")
     fun test_uuidutils_for_random_uuid() {
         val uuidJava: java.util.UUID = java.util.UUID.randomUUID()
-        val uuid: UUID = UUID.newBuilder().setMsb(uuidJava.mostSignificantBits).setLsb(uuidJava.leastSignificantBits).build()
+        val uuid: UUID = uUID {
+            msb = uuidJava.mostSignificantBits
+            lsb = uuidJava.leastSignificantBits
+        }
         val version: Optional<UuidUtils.Version> = UuidUtils.getVersion(uuid)
         val time: Optional<Long> = UuidUtils.getTime(uuid)
         val bytes = MicroUuidSerializer.instance().serialize(uuid)
@@ -189,7 +193,10 @@ class UUIDFactoryTest {
     @Test
     @DisplayName("Test UuidUtils for empty UUID")
     fun test_uuidutils_for_empty_uuid() {
-        val uuid: UUID = UUID.newBuilder().setMsb(0L).setLsb(0L).build()
+        val uuid: UUID = uUID {
+            msb = 0L
+            lsb = 0L
+        }
         val version: Optional<UuidUtils.Version> = UuidUtils.getVersion(uuid)
         val time: Optional<Long> = UuidUtils.getTime(uuid)
         val bytes = MicroUuidSerializer.instance().serialize(uuid)
@@ -229,7 +236,10 @@ class UUIDFactoryTest {
     @Test
     @DisplayName("Test UuidUtils fromString an invalid built UUID")
     fun test_uuidutils_from_invalid_uuid() {
-        val uuid = UUID.newBuilder().setMsb((9 shl 12).toLong()).setLsb(0L).build() // Invalid UUID type
+        val uuid = uUID {
+            msb = (9 shl 12).toLong()
+            lsb = 0L
+        } // Invalid UUID type
         assertFalse(UuidUtils.getVersion(uuid).isPresent)
         assertFalse(UuidUtils.getTime(uuid).isPresent)
         assertTrue(MicroUuidSerializer.instance().serialize(uuid).isNotEmpty())
@@ -243,18 +253,18 @@ class UUIDFactoryTest {
     @Test
     @DisplayName("Test UuidUtils fromString with invalid string")
     fun test_uuidutils_fromstring_with_invalid_string() {
-        val  uuid:UUID = LongUuidSerializer.instance().deserialize(null)
+        val uuid: UUID = LongUuidSerializer.instance().deserialize(null)
         assertTrue(uuid == UUID.getDefaultInstance())
-        val  uuid1:UUID = LongUuidSerializer.instance().deserialize("")
+        val uuid1: UUID = LongUuidSerializer.instance().deserialize("")
         assertTrue(uuid1 == UUID.getDefaultInstance())
     }
 
     @Test
     @DisplayName("Test UuidUtils fromBytes with invalid bytes")
     fun test_uuidutils_frombytes_with_invalid_bytes() {
-        val  uuid:UUID = MicroUuidSerializer.instance().deserialize(null)
+        val uuid: UUID = MicroUuidSerializer.instance().deserialize(null)
         assertTrue(uuid == UUID.getDefaultInstance())
-        val uuid1:UUID= MicroUuidSerializer.instance().deserialize(ByteArray(0))
+        val uuid1: UUID = MicroUuidSerializer.instance().deserialize(ByteArray(0))
         assertTrue(uuid1 == UUID.getDefaultInstance())
     }
 

--- a/src/test/kotlin/org/eclipse/uprotocol/uuid/validator/UuidValidatorTest.kt
+++ b/src/test/kotlin/org/eclipse/uprotocol/uuid/validator/UuidValidatorTest.kt
@@ -28,11 +28,12 @@ import org.eclipse.uprotocol.uuid.validate.UuidValidator
 import org.eclipse.uprotocol.v1.UCode
 import org.eclipse.uprotocol.v1.UStatus
 import org.eclipse.uprotocol.v1.UUID
+import org.eclipse.uprotocol.v1.uUID
 import org.eclipse.uprotocol.validation.ValidationResult
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.time.Instant
-import org.junit.jupiter.api.Assertions.*
 
 class UuidValidatorTest {
     @Test
@@ -47,15 +48,18 @@ class UuidValidatorTest {
     @Test
     @DisplayName("Test Good uuid Check")
     fun test_good_uuid_string() {
-        val status: UStatus = UuidValidator.Validators.UPROTOCOL.validator()
-            .validate(UuidFactory.Factories.UPROTOCOL.factory().create())
+        val status: UStatus =
+            UuidValidator.Validators.UPROTOCOL.validator().validate(UuidFactory.Factories.UPROTOCOL.factory().create())
         assertEquals(status, ValidationResult.STATUS_SUCCESS)
     }
 
     @Test
     @DisplayName("Test fetching the invalid Validator for when UUID passed is garbage")
     fun test_invalid_uuid() {
-        val uuid: UUID = UUID.newBuilder().setMsb(0L).setLsb(0L).build()
+        val uuid: UUID = uUID {
+            msb = 0L
+            lsb = 0L
+        }
         val status: UStatus = UuidValidator.getValidator(uuid).validate(uuid)
         assertEquals(UCode.INVALID_ARGUMENT, status.code)
         assertEquals("Invalid UUID Version,Invalid UUID Variant,Invalid UUID Time", status.message)
@@ -84,10 +88,15 @@ class UuidValidatorTest {
     @DisplayName("Test UUIDv8 validator for invalid types")
     fun test_uuidv8_with_invalid_types() {
         val uuidv6: UUID = UuidFactory.Factories.UUIDV6.factory().create()
-        val uuid: UUID = UUID.newBuilder().setMsb(0L).setLsb(0L).build()
+        val uuid: UUID = uUID {
+            msb = 0L
+            lsb = 0L
+        }
         val uuidJava: java.util.UUID = java.util.UUID.randomUUID()
-        val uuidv4: UUID = UUID.newBuilder().setMsb(uuidJava.mostSignificantBits)
-            .setLsb(uuidJava.leastSignificantBits).build()
+        val uuidv4: UUID = uUID {
+            msb = uuidJava.mostSignificantBits
+            lsb = uuidJava.leastSignificantBits
+        }
         val validator: UuidValidator = UuidValidator.Validators.UPROTOCOL.validator()
         assertNotNull(validator)
         val status: UStatus = validator.validate(uuidv6)
@@ -114,7 +123,7 @@ class UuidValidatorTest {
     @Test
     @DisplayName("Test UUIDv6 with bad variant")
     fun test_uuidv6_with_bad_variant() {
-        val uuid: UUID =LongUuidSerializer.instance().deserialize("1ee57e66-d33a-65e0-4a77-3c3f061c1e9e")
+        val uuid: UUID = LongUuidSerializer.instance().deserialize("1ee57e66-d33a-65e0-4a77-3c3f061c1e9e")
         assertFalse(uuid == UUID.getDefaultInstance())
         val validator: UuidValidator = UuidValidator.getValidator(uuid)
         assertNotNull(validator)
@@ -126,7 +135,10 @@ class UuidValidatorTest {
     @Test
     @DisplayName("Test UUIDv6 with invalid UUID")
     fun test_uuidv6_with_invalid_uuid() {
-        val uuid: UUID = UUID.newBuilder().setMsb(9 shl 12).setLsb(0L).build()
+        val uuid: UUID = uUID {
+            msb = 9 shl 12
+            lsb = 0L
+        }
         val validator: UuidValidator = UuidValidator.Validators.UUIDV6.validator()
         assertNotNull(validator)
         val status: UStatus = validator.validate(uuid)


### PR DESCRIPTION
This commit addresses #9 

Changes made:
-Add protobuf kotlin plugin
-Pulls uprotocol-core-api from git instead of maven
-Generate kotlin protobuf classes
-Replace java proto classes with Kotlin equivalents
-Add cloudevent readme